### PR TITLE
remove global.___ in favor of undefined keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ milesToKm(10); // 16.2
 ```js
 import partial from 'just-partial-it';
 
-const cubedRoot = partial(Math.pow, _, 1/3);
+const cubedRoot = partial(Math.pow, undefined, 1/3);
 cubedRoot(10).toFixed(1); // 56.7
 cubedRoot(35).toFixed(1); // 16.2
 ```
@@ -304,15 +304,14 @@ I welcome pull requests for additional utilities (and corrections to existing on
   * favor for loops over high order functions
   * don't repeatedly access the same property, assign to a var
   * write es5
-* api 
+* api
   * keep the api it simple and intuitive
   * avoid edge case arguments whenever possible
 * README
   * limit README to examples of each use case
   * if you must explain the api (see api section) add a comment in the README example code
   * add a section in the general README that matches the README for your module
-    * don't forget to add a reference in the table of contents 
+    * don't forget to add a reference in the table of contents
 * tests
   * write a test for each use case
   * include tests for all README examples
-

--- a/packages/function-partial/README.md
+++ b/packages/function-partial/README.md
@@ -6,7 +6,7 @@ Guilt-free utilities for every occasion.
 ```js
 import partial from 'just-partial-it';
 
-const cubedRoot = partial(Math.pow, _, 1/3);
+const cubedRoot = partial(Math.pow, undefined, 1/3);
 cubedRoot(10).toFixed(1); // 56.7
 cubedRoot(35).toFixed(1); // 16.2
 ```  

--- a/packages/function-partial/index.js
+++ b/packages/function-partial/index.js
@@ -6,9 +6,6 @@ module.exports = partial;
   cubedRoot(35).toFixed(1); // 16.2
 */
 
-var globalObj = global || self;
-globalObj.___ = {};
-
 function partial(fn /*, arg1, arg2 etc */) {
   var partialArgs = [].slice.call(arguments, 1);
   if (!partialArgs.length) {
@@ -18,7 +15,7 @@ function partial(fn /*, arg1, arg2 etc */) {
     var argIndex = 0, derivedArgs = [];
     for (var i = 0; i < partialArgs.length; i++) {
       var thisPartialArg = partialArgs[i];
-      derivedArgs[i] = thisPartialArg === globalObj.___ ? arguments[argIndex++] : thisPartialArg;
+      derivedArgs[i] = thisPartialArg === undefined ? arguments[argIndex++] : thisPartialArg;
     }
     return fn.apply(this, derivedArgs);
   };

--- a/test/function-partial/index.js
+++ b/test/function-partial/index.js
@@ -1,11 +1,11 @@
 var test = require('tape');
 var partial = require('../../packages/function-partial');
 
-var _ = global.___;
+// var _ = global.___;
 
 test('binds to supplied arguments placeholders', function (t) {
   t.plan(2);
-  var cubeRoot = partial(Math.pow, _, 1 / 3);
+  var cubeRoot = partial(Math.pow, undefined, 1 / 3);
   t.equal(cubeRoot(10).toFixed(1), '2.2');
   t.equal(cubeRoot(35).toFixed(1), '3.3');
   t.end();
@@ -15,7 +15,7 @@ test('surplus supplied arguments ignored', function (t) {
   function max() {
     return Math.max.apply(null, arguments);
   }
-  var atLeast4 = partial(max, _, 4);
+  var atLeast4 = partial(max, undefined, 4);
   t.equal(atLeast4(7), 7);
   t.equal(atLeast4(3, 9), 4);
   t.end();
@@ -38,7 +38,7 @@ test('executes in the correct context', function (t) {
   function nthRoot(input, n) {
     return Math.pow(input, 1 / n).toFixed(this.dps);
   }
-  var fourthRoot = partial(nthRoot, _, 4);
+  var fourthRoot = partial(nthRoot, undefined, 4);
   t.equal(fourthRoot.call({dps: 0}, 4345), '8');
   t.equal(fourthRoot.call({dps: 2}, 4345), '8.12');
   t.end();

--- a/test/function-partial/index.js
+++ b/test/function-partial/index.js
@@ -1,8 +1,6 @@
 var test = require('tape');
 var partial = require('../../packages/function-partial');
 
-// var _ = global.___;
-
 test('binds to supplied arguments placeholders', function (t) {
   t.plan(2);
   var cubeRoot = partial(Math.pow, undefined, 1 / 3);


### PR DESCRIPTION
The documentation is unclear that `partial()` expects to be passed `global.___` as the marker for a missing variable. Using `undefined` is explicit an clearer in intention and doesn't require additional global definitions.