### PR TITLE
Don't throw on array-last when input is undefined or null

### DIFF
--- a/packages/array-last/index.js
+++ b/packages/array-last/index.js
@@ -7,5 +7,5 @@ module.exports = last;
 */
 
 function last(arr) {
-  return arr[arr.length - 1];
+  return arr != null ? arr[arr.length - 1] : undefined;
 }

--- a/test/array-last/index.js
+++ b/test/array-last/index.js
@@ -20,3 +20,11 @@ test('empty arrays return undefined', function (t) {
   t.equal(last([]), undefined);
   t.end();
 });
+
+test('undefined inputs don\'t throw and return undefined', function (t) {
+  t.plan(3);
+  t.equal(last(), undefined);
+  t.equal(last(undefined), undefined);
+  t.equal(last(null), undefined);
+  t.end();
+});


### PR DESCRIPTION
On several ocassions I'm interested in the last value of an array, but the input might be undefined. This PR ensures that `last` doesn't throw if the input `arr` is either null or undefined, so that it's not necessary to do something like `last(arr || [])`.

Feel free to close this if handling this edge input case is invalid.