### PR TITLE
Make curry translate a polyadic function to a sequence of nested unary functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ import curry from 'just-curry-it';
 function converter(ratio, input) {
   return (input*ratio).toFixed(1);
 }
-const milesToKm = curry(converter, 1.62);
+const milesToKm = curry(converter)(1.62);
 milesToKm(35); // 56.7
 milesToKm(10); // 16.2
 ```

--- a/packages/function-curry/README.md
+++ b/packages/function-curry/README.md
@@ -11,7 +11,7 @@ import curry from 'just-curry-it';
 function converter(ratio, input) {
   return (input*ratio).toFixed(1);
 }
-const milesToKm = curry(converter, 1.62);
+const milesToKm = curry(converter)(1.62);
 milesToKm(35); // 56.7
 milesToKm(10); // 16.2
 ```

--- a/packages/function-curry/index.js
+++ b/packages/function-curry/index.js
@@ -11,17 +11,17 @@ module.exports = curry;
 
 function curry(fn /* arg1, arg2 etc */) {
   var fnArgs = [].slice.call(arguments, 1);
-  if (fnArgs.length >= fn.length) {
+  if (fn.length && fnArgs.length >= fn.length) {
     return fn.apply(this, fnArgs);
   }
-  return function currier() {
+  return function curried() {
     var curriedArgs = [].slice.call(arguments);
     var args = fnArgs.concat(curriedArgs);
     if (args.length >= fn.length) {
       return fn.apply(this, args);
     } else {
       return function () {
-        return currier.apply(this, curriedArgs.concat([].slice.call(arguments)));
+        return curried.apply(this, curriedArgs.concat([].slice.call(arguments)));
       };
     }
   };

--- a/packages/function-curry/index.js
+++ b/packages/function-curry/index.js
@@ -9,12 +9,20 @@ module.exports = curry;
   milesToKm(10); // 16.2
 */
 
-function curry(fn /*, arg1, arg2 etc */) {
-  var curriedArgs = [].slice.call(arguments, 1);
-  if (!curriedArgs.length) {
-    return fn;
+function curry(fn /* arg1, arg2 etc */) {
+  var fnArgs = [].slice.call(arguments, 1);
+  if (fnArgs.length >= fn.length) {
+    return fn.apply(this, fnArgs);
   }
-  return function () {
-    return fn.apply(this, curriedArgs.concat([].slice.call(arguments)));
+  return function currier() {
+    var curriedArgs = [].slice.call(arguments);
+    var args = fnArgs.concat(curriedArgs);
+    if (args.length >= fn.length) {
+      return fn.apply(this, args);
+    } else {
+      return function () {
+        return currier.apply(this, curriedArgs.concat([].slice.call(arguments)));
+      };
+    }
   };
 }

--- a/packages/function-curry/index.js
+++ b/packages/function-curry/index.js
@@ -4,24 +4,20 @@ module.exports = curry;
   function converter(ratio, input) {
     return (input*ratio).toFixed(1);
   }
-  var milesToKm = curry(converter, 1.62);
+  var curriedConverter = curry(converter)
+  var milesToKm = curriedConverter(1.62);
   milesToKm(35); // 56.7
   milesToKm(10); // 16.2
 */
 
-function curry(fn /* arg1, arg2 etc */) {
-  var fnArgs = [].slice.call(arguments, 1);
-  if (fn.length && fnArgs.length >= fn.length) {
-    return fn.apply(this, fnArgs);
-  }
+function curry(fn) {
   return function curried() {
-    var curriedArgs = [].slice.call(arguments);
-    var args = fnArgs.concat(curriedArgs);
+    var args = [].slice.call(arguments);
     if (args.length >= fn.length) {
       return fn.apply(this, args);
     } else {
       return function () {
-        return curried.apply(this, curriedArgs.concat([].slice.call(arguments)));
+        return curried.apply(this, args.concat([].slice.call(arguments)));
       };
     }
   };

--- a/test/function-curry/index.js
+++ b/test/function-curry/index.js
@@ -2,27 +2,14 @@ var test = require('tape');
 var curry = require('../../packages/function-curry');
 
 test('binds curried arguments to supplied arguments', function (t) {
-  t.plan(4);
-  function converter(ratio, input) {
-    return (input * ratio).toFixed(1);
-  }
-  var milesToKm = curry(converter, 1.62);
-  t.equal(milesToKm(), 'NaN');
-  t.equal(milesToKm(35), '56.7');
-  t.equal(milesToKm(10), '16.2');
-  t.equal(milesToKm(10, 35), '16.2');
-  t.end();
-});
-
-test('returns original function if zero currying args are passed', function (t) {
   t.plan(3);
   function converter(ratio, input) {
     return (input * ratio).toFixed(1);
   }
-  var milesToKm = curry(converter);
-  t.equal(converter, milesToKm);
-  t.equal(converter(1.62, 35), '56.7');
-  t.equal(milesToKm(1.62, 35), '56.7');
+  var milesToKm = curry(converter, 1.62);
+  t.equal(milesToKm(35), '56.7');
+  t.equal(milesToKm(10), '16.2');
+  t.equal(milesToKm(10, 35), '16.2');
   t.end();
 });
 

--- a/test/function-curry/index.js
+++ b/test/function-curry/index.js
@@ -13,6 +13,24 @@ test('binds curried arguments to supplied arguments', function (t) {
   t.end();
 });
 
+test('returns a curried function even if zero currying args are passed', function (t) {
+  t.plan(2);
+  function converter(ratio, input) {
+    return (input * ratio).toFixed(1);
+  }
+  var milesToKm = curry(converter);
+  t.equal(milesToKm(1.62, 35), '56.7');
+  t.equal(milesToKm(1.62)(35), '56.7');
+  t.end();
+});
+
+test('still returns a function for zero-arity functions', function (t) {
+  t.plan(2);
+  function nothing() {}
+  t.equal(typeof curry(nothing), 'function');
+  t.equal(typeof curry(nothing, 1, 2, 3), 'function');
+});
+
 test('executes in the correct context', function (t) {
   t.plan(2);
   function converter(ratio, input) {

--- a/test/function-curry/index.js
+++ b/test/function-curry/index.js
@@ -36,3 +36,14 @@ test('executes in the correct context', function (t) {
   t.equal(milesToKm.call({dps: 2}, 35), '56.70');
   t.end();
 });
+
+test('converts n-ary function to a sequence of nested unary functions', function (t) {
+  t.plan(2);
+  function addThree(x, y, z) {
+    return x + y + z;
+  }
+  var addTwoTo2 = curry(addThree, 2);
+  t.equal(typeof addTwoTo2(3), 'function');
+  t.equal(addTwoTo2(5)(8), 16);
+  t.end();
+})

--- a/test/function-curry/index.js
+++ b/test/function-curry/index.js
@@ -25,12 +25,14 @@ test('executes in the correct context', function (t) {
 });
 
 test('converts n-ary function to a sequence of nested unary functions', function (t) {
-  t.plan(2);
+  t.plan(4);
   function addThree(x, y, z) {
     return x + y + z;
   }
   var addTwoTo2 = curry(addThree, 2);
   t.equal(typeof addTwoTo2(3), 'function');
-  t.equal(addTwoTo2(5)(8), 16);
+  t.equal(addTwoTo2(5)(8), 15);
+  t.equal(addTwoTo2(13, 21), 36);
+  t.equal(curry(addThree, 34, 55, 89), 178);
   t.end();
-})
+});

--- a/test/function-curry/index.js
+++ b/test/function-curry/index.js
@@ -1,26 +1,26 @@
 var test = require('tape');
 var curry = require('../../packages/function-curry');
 
-test('binds curried arguments to supplied arguments', function (t) {
+test('returns a curried function', function (t) {
+  t.plan(1);
+  function converter(ratio, input) {
+    return (input * ratio).toFixed(1);
+  }
+  var curriedConverter = curry(converter);
+  var milesToKm = curriedConverter(1.62);
+  t.equal(milesToKm(35), '56.7');
+  t.end();
+});
+
+test('does not bind supplied arguments', function (t) {
   t.plan(3);
   function converter(ratio, input) {
     return (input * ratio).toFixed(1);
   }
   var milesToKm = curry(converter, 1.62);
-  t.equal(milesToKm(35), '56.7');
-  t.equal(milesToKm(10), '16.2');
-  t.equal(milesToKm(10, 35), '16.2');
-  t.end();
-});
-
-test('returns a curried function even if zero currying args are passed', function (t) {
-  t.plan(2);
-  function converter(ratio, input) {
-    return (input * ratio).toFixed(1);
-  }
-  var milesToKm = curry(converter);
-  t.equal(milesToKm(1.62, 35), '56.7');
-  t.equal(milesToKm(1.62)(35), '56.7');
+  t.equal(typeof milesToKm(35), 'function');
+  t.equal(milesToKm(1.62)(10), '16.2');
+  t.equal(milesToKm(1.62, 10), '16.2');
   t.end();
 });
 
@@ -36,7 +36,7 @@ test('executes in the correct context', function (t) {
   function converter(ratio, input) {
     return (input * ratio).toFixed(this.dps);
   }
-  var milesToKm = curry(converter, 1.62);
+  var milesToKm = curry(converter)(1.62);
   t.equal(milesToKm.call({dps: 0}, 35), '57');
   t.equal(milesToKm.call({dps: 2}, 35), '56.70');
   t.end();
@@ -47,10 +47,10 @@ test('converts n-ary function to a sequence of nested unary functions', function
   function addThree(x, y, z) {
     return x + y + z;
   }
-  var addTwoTo2 = curry(addThree, 2);
+  var addTwoTo2 = curry(addThree)(2);
   t.equal(typeof addTwoTo2(3), 'function');
   t.equal(addTwoTo2(5)(8), 15);
   t.equal(addTwoTo2(13, 21), 36);
-  t.equal(curry(addThree, 34, 55, 89), 178);
+  t.equal(curry(addThree)(34)(55)(89), 178);
   t.end();
 });


### PR DESCRIPTION
so:

```js
function addThree(x, y, z) {
  return x + y + z
}

curry(addThree)(1)(4)(4) //=> 9
curry(addThree)(1, 4)(4) //=> 9
curry(addThree)(1, 4, 4) //=> 9
curry(addThree)(1)(4, 4) //=> 9
```

might be considered a breaking change because `curry(convertor)` no longer returns you `convertor`, but a curried version of `convertor`.