### PR TITLE
Adding object-entries in kind with object-values

### DIFF
--- a/packages/object-entries/README.md
+++ b/packages/object-entries/README.md
@@ -1,0 +1,21 @@
+## just-entries
+
+Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
+Guilt-free utilities for every occasion.
+
+[Try it now](http://anguscroll.com/just/just-entries)
+
+```js
+const entries = require('just-entries');
+
+// Object:
+entries({c: 8, a: 4}); // [['c', 8], ['a', 4]]
+entries({b: {bb: 4}, a: {aa: 2}}); // [['b', {bb: 4}], ['a', {aa: 2}]]
+entries({}); // []
+
+// Array:
+entries([{c: 8}, {a: 4}]); // [[0, {c: 8}], [1, {a: 4}]]
+entries(['À', 'mauvais', 'ouvrier', 'point', 'de', 'bon', 'outil'])
+// [[0, 'À'], [1, 'mauvais'] ... [6, 'outil']]
+entries([]); // []
+```

--- a/packages/object-entries/index.js
+++ b/packages/object-entries/index.js
@@ -1,0 +1,28 @@
+module.exports = entries;
+
+/*
+  // Object:
+  entries({c: 8, a: 4}); // [['c', 8], ['a', 4]]
+  entries({b: {bb: 4}, a: {aa: 2}}); // [['b', {bb: 4}], ['a', {aa: 2}]]
+  entries({}); // []
+
+  // Array:
+  entries([{c: 8}, {a: 4}]); // [[0, {c: 8}], [1, {a: 4}]]
+  entries(['À', 'mauvais', 'ouvrier', 'point', 'de', 'bon', 'outil'])
+          // [[0, 'À'], [1, 'mauvais'] ... [6, 'outil']]
+  entries([]); // []
+*/
+
+function entries(obj) {
+  if (typeof obj != 'object' && typeof obj != 'function' || obj == null) {
+    throw new Error('argument to `entries` must be an object');
+  }
+
+  var result = [];
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      result.push([key, obj[key]]);
+    }
+  }
+  return result;
+}

--- a/packages/object-entries/package.json
+++ b/packages/object-entries/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "just-entries",
+  "version": "1.0.0",
+  "description": "return object entries as an array of [key, value] pairs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "https://github.com/angus-c/just",
+  "keywords": [
+    "object",
+    "entries",
+    "no-dependencies",
+    "just"
+  ],
+  "author": "Johnny Megahan",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angus-c/just/issues"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,7 @@ require('./collection-flush');
 require('./object-is-empty');
 require('./object-is-circular');
 require('./object-is-primitive');
+require('./object-entries');
 require('./object-extend');
 require('./object-filter');
 require('./object-map');

--- a/test/object-entries/index.js
+++ b/test/object-entries/index.js
@@ -1,0 +1,39 @@
+var test = require('tape');
+var entries = require('../../packages/object-entries');
+
+test('regular objects return pairs of property/value', function (t) {
+  t.plan(3);
+  t.deepEqual(entries({c: 8, a: 4}), [['c', 8], ['a', 4]]);
+  t.deepEqual(entries({b: {bb: 4}, a: {aa: 2}}), [['b', {bb: 4}], ['a', {aa: 2}]]);
+  t.deepEqual(entries({}), []);
+  t.end();
+});
+
+test('arrays return pairs of index/value', function (t) {
+  t.plan(3);
+  t.deepEqual(entries([{c: 8}, {a: 4}]), [['0', {c: 8}], ['1', {a: 4}]]);
+  t.deepEqual(entries([]), []);
+  t.notEqual(entries([]), []);
+  t.end();
+});
+
+test('irregular objects return pairs of property/value', function (t) {
+  t.plan(3);
+  t.deepEqual(
+    entries(new String('hello')),
+    [['0', 'h'], ['1', 'e'], ['2', 'l'], ['3', 'l'], ['4', 'o']]
+  );
+  t.deepEqual(entries(function (a, b) {return a + b;}), []);
+  var fn = function () {};
+  fn.a = 4;
+  t.deepEqual(entries(fn), [['a', 4]]);
+  t.end();
+});
+
+test('primitives throw exceptions', function (t) {
+  t.plan(4);
+  t.throws(function () {entries(1);}, Error, 'number');
+  t.throws(function () {entries(true);}, Error, 'boolean');
+  t.throws(function () {entries(undefined);}, Error, 'undefined');
+  t.throws(function () {entries(null);}, Error, 'null');
+});


### PR DESCRIPTION
Here object-entries acts a little bit like the proposed Object.entries but
stays in line with the object-values implementation. That is mostly to
say that it will work on entries(new String('abc')) but not entries('abc').

It will, generally, take an object and return it's key/value pairs.

    entries({b: 4, a: 8}) // [['b', 4], ['a', 8]]