### PR TITLE
Add just-split-at package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/angus-c/just.svg?branch=master)](http://travis-ci.org/angus-c/just.js)
 
-A library of **zero-dependency** npm modules that do just do one thing.  
-Guilt-free utilities for every occasion.  
+A library of **zero-dependency** npm modules that do just do one thing.
+Guilt-free utilities for every occasion.
 Perfect for the Mobile Web.
 
 We welcome contributions. Please follow the [contribution guidelines](#new-module-guidelines) below.
@@ -15,19 +15,19 @@ We welcome contributions. Please follow the [contribution guidelines](#new-modul
 [The Zen of Dependency-Free –- Why I wrote Just](https://medium.com/@angustweets/just-a12d54221f65#.ljib0mfr5)
 
 ## The Modules :package:
-  
+
 * [Objects](#objects)
   * [just-extend](#just-extend)
   * [just-values](#just-values)
-  * [just-entries](#just-entries)  
+  * [just-entries](#just-entries)
   * [just-pick](#just-pick)
   * [just-omit](#just-omit)
   * [just-filter-object](#just-filter-object)
   * [just-map-object](#just-map-object)
   * [just-reduce-object](#just-reduce-object)
   * [just-is-empty](#just-is-empty)
-  * [just-is-circular](#just-is-circular)  
-  * [just-is-primitive](#just-is-primitive)      
+  * [just-is-circular](#just-is-circular)
+  * [just-is-primitive](#just-is-primitive)
   * [just-safe-get](#just-safe-get)
   * [just-safe-set](#just-safe-set)
   * [just-typeof](#just-typeof)
@@ -35,34 +35,34 @@ We welcome contributions. Please follow the [contribution guidelines](#new-modul
 * [Collections](#collections)
   * [just-compare](#just-compare)
   * [just-pluck-it](#just-pluck-it)
-  * [just-flush](#just-flush)  
+  * [just-flush](#just-flush)
 * [Arrays](#arrays)
   * [just-unique](#just-unique)
   * [just-flatten-it](#just-flatten-it)
   * [just-index](#just-index)
   * [just-insert](#just-insert)
   * [just-intersect](#just-intersect)
-  * [just-compact](#just-compact)  
+  * [just-compact](#just-compact)
   * [just-last](#just-last)
   * [just-tail](#just-tail)
   * [just-random](#just-random)
-  * [just-shuffle](#just-shuffle)  
+  * [just-shuffle](#just-shuffle)
   * [just-range](#just-range)
   * [just-remove](#just-remove)
   * [just-union](#just-union)
 * [Strings](#strings)
   * [just-template](#just-template)
   * [just-truncate](#just-truncate)
-  * [just-prune](#just-prune)      
-  * [just-squash](#just-squash)  
+  * [just-prune](#just-prune)
+  * [just-squash](#just-squash)
   * [just-left-pad](#just-left-pad)
   * [just-right-pad](#just-right-pad)
-  * [just-camel-case](#just-camel-case)              
-  * [just-kebab-case](#just-kebab-case)              
-  * [just-snake-case](#just-snake-case)                  
+  * [just-camel-case](#just-camel-case)
+  * [just-kebab-case](#just-kebab-case)
+  * [just-snake-case](#just-snake-case)
 * [Numbers](#numbers)
-  * [just-clamp](#just-clamp)  
-  * [just-modulo](#just-modulo)  
+  * [just-clamp](#just-clamp)
+  * [just-modulo](#just-modulo)
 * [Functions](#functions)
   * [just-compose](#just-compose)
   * [just-curry-it](#just-curry-it)
@@ -70,7 +70,7 @@ We welcome contributions. Please follow the [contribution guidelines](#new-modul
   * [just-flip](#just-flip)
   * [just-partial-it](#just-partial-it)
   * [just-debounce-it](#just-debounce-it)
-  * [just-throttle](#just-throttle)  
+  * [just-throttle](#just-throttle)
 
 ### Objects
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We welcome contributions. Please follow the [contribution guidelines](#new-modul
   * [just-tail](#just-tail)
   * [just-random](#just-random)
   * [just-shuffle](#just-shuffle)
+  * [just-split-at](#just-split-at)
   * [just-range](#just-range)
   * [just-remove](#just-remove)
   * [just-union](#just-union)
@@ -563,6 +564,21 @@ shuffle(); // undefined
 shuffle(undefined); // undefined
 shuffle(null); // undefined
 shuffle({}); // undefined
+```
+
+### [just-split-at](https://www.npmjs.com/package/just-split-at)
+:icecream:[`Try It`](http://anguscroll.com/just/just-split-at)
+
+`npm install just-split-at`
+
+```js
+import splitAt from 'just-split-at';
+
+splitAt([1, 2, 3, 4, 5], 2); // [[1, 2], [3, 4, 5]]
+splitAt([{a: 1}, {b: 1}, {c: 1}], -1); // [[{a: 1}, {b: 1}], [{c: 1}]]
+splitAt([], 2); // [[], []]
+splitAt(null, 1); // undefined
+splitAt(undefined, 1); // undefined
 ```
 
 ### [just-range](https://www.npmjs.com/package/just-range)

--- a/packages/array-split-at/README.md
+++ b/packages/array-split-at/README.md
@@ -1,0 +1,16 @@
+## just-split-at
+
+Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
+Guilt-free utilities for every occasion.
+
+[Try it now](http://anguscroll.com/just/just-split-at)
+
+```js
+import splitAt from 'just-split-at';
+
+splitAt([1, 2, 3, 4, 5], 2); // [[1, 2], [3, 4, 5]]
+splitAt([{a: 1}, {b: 1}, {c: 1}], -1); // [[{a: 1}, {b: 1}], [{c: 1}]]
+splitAt([], 2); // [[], []]
+splitAt(null, 1); // undefined
+splitAt(undefined, 1); // undefined
+```

--- a/packages/array-split-at/index.js
+++ b/packages/array-split-at/index.js
@@ -1,0 +1,13 @@
+module.exports = splitAt;
+
+/*
+  splitAt([1, 2, 3, 4, 5], 2); // [[1, 2], [3, 4, 5]]
+  splitAt([{a: 1}, {b: 1}, {c: 1}], -1); // [[{a: 1}, {b: 1}], [{c: 1}]]
+  splitAt([], 2); // [[], []]
+  splitAt(null, 1); // undefined
+  splitAt(undefined, 1); // undefined
+*/
+
+function splitAt(array, n) {
+  return Array.isArray(array) ? [array.slice(0, n), array.slice(n)] : undefined;
+}

--- a/packages/array-split-at/package.json
+++ b/packages/array-split-at/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "just-split-at",
+  "version": "1.0.0",
+  "description": "splits an array into two at a given position",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "https://github.com/angus-c/split-at",
+  "keywords": [
+    "array",
+    "split-at",
+    "no-dependencies",
+    "just"
+  ],
+  "author": "Cameron Hunter",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angus-c/just/issues"
+  }
+}

--- a/packages/array-tail/README.md
+++ b/packages/array-tail/README.md
@@ -1,12 +1,12 @@
-## just-last
+## just-tail
 
-Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.  
+Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
 Guilt-free utilities for every occasion.
 
-[Try it now](http://anguscroll.com/just/just-last)
+[Try it now](http://anguscroll.com/just/just-tail)
 
 ```js
-import last from 'just-tail';
+import tail from 'just-tail';
 
 tail([1, 2, 3, 4, 5]); // [2, 3, 4, 5]
 tail([{a: 1}, {b: 1}, {c: 1}]); // [{b: 1}, {c: 1}]
@@ -15,4 +15,4 @@ tail([]); // []
 tail(); // undefined
 tail(null); // undefined
 tail(undefined); // undefined
-```  
+```

--- a/test/array-split-at/index.js
+++ b/test/array-split-at/index.js
@@ -1,0 +1,30 @@
+var test = require('tape');
+var splitAt = require('../../packages/array-split-at');
+
+test('splits array into two at a given position within the array bounds', function (t) {
+  t.deepEqual(splitAt([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4, 5]]);
+});
+
+test('splits array into two at a given position outside the array bounds', function (t) {
+  t.deepEqual(splitAt([1, 2, 3, 4, 5], 10), [[1, 2, 3, 4, 5], []]);
+});
+
+test('splits array into two at a given negative position within the array bounds', function (t) {
+  t.deepEqual(splitAt([1, 2, 3, 4, 5], -1), [[1, 2, 3, 4], [5]]);
+});
+
+test('splits array into two at a given negative position outside the array bounds', function (t) {
+  t.deepEqual(splitAt([1, 2, 3, 4, 5], -10), [[], [1, 2, 3, 4, 5]]);
+});
+
+test('splits array into two at an empty array', function (t) {
+  t.deepEqual(splitAt([], 2), [[], []]);
+});
+
+test('undefined inputs don\'t throw and return undefined', function (t) {
+  t.plan(3);
+  t.equal(splitAt(), undefined);
+  t.equal(splitAt(undefined), undefined);
+  t.equal(splitAt(null), undefined);
+  t.end();
+});

--- a/test/function-debounce/index.js
+++ b/test/function-debounce/index.js
@@ -5,7 +5,7 @@ test('waits for n ms then runs once', function (t) {
   t.plan(1);
   var callCounter = 0;
   var fn = debounce(
-    function () {callCounter++},
+    function () {callCounter++;},
     100
   );
 
@@ -23,7 +23,7 @@ test('when callFirst is true, runs once, waits for n ms then runs again', functi
   t.plan(2);
   var callCounter = 0;
   var fn = debounce(
-    function () {callCounter++},
+    function () {callCounter++;},
     100,
     true
   );


### PR DESCRIPTION
A new array package to split an array into two at a given position. Examples:

```javascript
import splitAt from 'just-split-at';

splitAt([1, 2, 3, 4, 5], 2); // [[1, 2], [3, 4, 5]]
splitAt([{a: 1}, {b: 1}, {c: 1}], -1); // [[{a: 1}, {b: 1}], [{c: 1}]]
splitAt([], 2); // [[], []]
splitAt(null, 1); // undefined
splitAt(undefined, 1); // undefined
```

PR also includes some minor cleanup of READMEs – happy to move to another PR if desired.