### PR TITLE
Issue: https://github.com/angus-c/just/issues/98

### DIFF
--- a/packages/collection-compare/index.js
+++ b/packages/collection-compare/index.js
@@ -23,7 +23,7 @@ function compare(value1, value2) {
   if ((value1 !== value1) && (value2 !== value2)) {
     return true;
   }
-  if (typeof value1 != typeof value2) {
+  if ({}.toString.call(value1) != {}.toString.call(value2)) {
     return false;
   }
   if (value1 !== Object(value1)) {

--- a/packages/collection-compare/package.json
+++ b/packages/collection-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-compare",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "compare two collections",
   "main": "index.js",
   "scripts": {

--- a/test/collection-compare/index.js
+++ b/test/collection-compare/index.js
@@ -165,3 +165,15 @@ test('alike dates return true', function(t) {
   t.notOk(compare(new Date(2016, 8, 3), new Date(2016, 8, 3, 16)));
   t.end();
 });
+
+// https://github.com/angus-c/just/issues/98
+test('unalike complex objects do not crash when objects/arrays become null', function(t) {
+  t.plan(2);
+  var value1 = {a: [4, 2], b: 3};
+  var value2 = {a: null, c: 3};
+  t.notOk(compare(value1, value2));
+  var value3 = {a: {a: 1}, b: 3};
+  var value4 = {a: null, c: 3};
+  t.notOk(compare(value3, value4));
+  t.end();
+});


### PR DESCRIPTION
This fixes a bug where compare would throw `TypeError: Cannot convert undefined or null to object` when a property goes from object to null.