### PR TITLE
Clean up object-pick comments

### DIFF
--- a/packages/object-pick/index.js
+++ b/packages/object-pick/index.js
@@ -3,8 +3,8 @@ module.exports = pick;
 /*
   var obj = {a: 3, b: 5, c: 9};
   pick(obj, ['a', 'c']); // {a: 3, c: 9}
-  pick(obj, a, c); // {a: 3, c: 9}
-  pick(obj, ['a', 'b', 'd']); // {a: 3, b: 5, d: undefined}
+  pick(obj, 'a', 'c'); // {a: 3, c: 9}
+  pick(obj, ['a', 'b', 'd']); // {a: 3, b: 5}
   pick(obj, ['a', 'a']); // {a: 3}
 */
 


### PR DESCRIPTION
1. Some quotes on strings were missing.
2. Picking non-existent keys is [no longer supported](https://github.com/angus-c/just/commit/2b4afcdd206a030ff7b74ae40541a6e6a2193d58#diff-3d976488e63ac579c491f3cf92a53176R14).