### PR TITLE
Add merge to top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,35 @@ extend('hello', {a: 4, b: 5}); // throws
 extend(3, {a: 4, b: 5}); // throws
 ```
 
+### [just-merge](https://www.npmjs.com/package/just-merge)
+
+:icecream:[`Try It`](http://anguscroll.com/just/just-merge)
+
+`npm install just-merge`
+
+```js
+import merge from 'just-merge';
+
+let obj = {a: 3, b: 5};
+merge(obj, {a: 4, c: 8}); // {a: 4, b: 5, c: 8}
+obj; // {a: 4, b: 5, c: 8}
+
+let obj = {a: 3, b: 5};
+merge({}, obj, {a: 4, c: 8}); // {a: 4, b: 5, c: 8}
+obj; // {a: 3, b: 5}
+
+let arr = [1, 2, 3];
+let obj = {a: 3, b: 5};
+merge(obj, {c: arr}); // {a: 3, b: 5, c: [1, 2, 3]}
+arr.push[4];
+obj; // {a: 3, b: 5, c: [1, 2, 3, 4]}
+
+merge({a: 4, b: 5}); // {a: 4, b: 5}
+merge(3, {a: 4, b: 5}); // throws
+merge({a: 4, b: 5}, 3); // throws
+merge({a: 4, b: 5}, {b: 4, c: 5}, 'c'); // throws
+```
+
 ### [just-values](https://www.npmjs.com/package/just-values)
 
 :icecream:[`Try It`](http://anguscroll.com/just/just-values)


### PR DESCRIPTION
I noticed that the link for `just-merge` didn't go anywhere on the top Read me, so I decided to update it. 