### PR TITLE
Introduce object-omit type definitions

### DIFF
--- a/packages/object-omit/index.d.ts
+++ b/packages/object-omit/index.d.ts
@@ -1,0 +1,29 @@
+/**
+ * The opposite of `just-pick`; this method creates an object composed of the
+ * own and inherited enumerable properties of `object` that are not omitted.
+ *
+ * @category Object
+ * @returns A new object with specified keys omitted from the source `object`.
+ * @example
+```ts
+var obj = {a: 3, b: 5, c: 9};
+omit(obj, ['a', 'c']); // {b: 5}
+omit(obj, a, c); // {b: 5}
+omit(obj, ['a', 'b', 'd']); // {c: 9}
+omit(obj, ['a', 'a']); // {b: 5, c: 9}
+```
+ */
+declare function omit<T extends object, K extends keyof T>(
+/**
+ * The source object.
+ */
+obj: T | null | undefined, 
+/**
+ * The property names to omit.
+ */
+remove: keyof T | Array<K | ReadonlyArray<K>>, 
+/**
+ * The property names to omit.
+ */
+...rest: Array<K | ReadonlyArray<K>>): any;
+export = omit;

--- a/test/object-omit/index.js
+++ b/test/object-omit/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 var test = require('../util/test')(__filename);
 var omit = require('../../packages/object-omit');
 var compare = require('../../packages/collection-compare');
@@ -35,6 +36,7 @@ test('omit using arguments', function(t) {
 test('omit using a non-existent key', function(t) {
   t.plan(1);
   var obj = {a: 3, b: 5, c: 9};
+  // @ts-ignore
   t.ok(compare(omit(obj, ['a', 'b', 'd']), {c: 9}));
   t.end();
 });


### PR DESCRIPTION
This PR just introduces the type definitions for `object-omit` w/o any TS source files. This is the bare minimum that's required to provide TypeScript support and doesn't touch the implementation whatsoever.