### PR TITLE
Fixed array elements REMOVE issue

### DIFF
--- a/packages/collection-diff-apply/index.js
+++ b/packages/collection-diff-apply/index.js
@@ -60,7 +60,7 @@ function diffApply(obj, diff, pathConverter) {
   var diffLength = diff.length;
   for (var i = 0; i < diffLength; i++) {
     var thisDiff = diff[i];
-    var subObject = obj;
+    var subObject = JSON.parse(JSON.stringify(obj));
     var thisOp = thisDiff.op;
     var thisPath = thisDiff.path;
     if (pathConverter) {


### PR DESCRIPTION
Directly referencing subObject to obj mutates obj in when op is REMOVE. This causes the code to break when subObject is an array and multiple elements are to be removed.