### PR TITLE
object-safe-get: even more lodash compat + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,8 +655,14 @@ get(obj.a, ['aa', 'aaa']); // 2
 get(obj.b, 'bb.bbb'); // undefined
 get(obj.b, ['bb', 'bbb']); // undefined
 
-get(null, 'a'); // null
-get(undefined, 'a'); //undefined
+get(obj.b, 'bb.bbb', 42); // 42
+get(obj.b, ['bb', 'bbb'], 42); // 42
+
+get(null, 'a'); // undefined
+get(undefined, ['a']); // undefined
+
+get(null, 'a', 42); // 42
+get(undefined, ['a'], 42); // 42
 
 const obj = { a: {} };
 const sym = Symbol();

--- a/TRADEOFFS.md
+++ b/TRADEOFFS.md
@@ -73,7 +73,7 @@ _e._ Lodash curry can be used as a constructor\
 _f._ instances of Lodash partial have a unique `instanceof` value.\
 _g._ Lodash clamp works without a lower bound arg. Just always requires lower and upper bounds.\
 _h._ If either bound is `NaN`, Lodash returns `0`, Just returns `NaN`.\
-_i._ just-get and just-set follows dotty for `(obj, ['a.b'])` style arguments. Lodash uses its own rules.\
+_i._ Lodash accepts array notation `(obj, 'a.b[2]')` while just-get and just-set follow [dotty](https://github.com/deoxxa/dotty): `(obj, 'a.b.2')`.\
 _j._ Lodash invokes `_.identity` when predicate function is nullish\
 _k._ Lodash accepts `_.property` shorthand instead of predicate function.\
 _l._ Lodash will flatten arguments to pick and omit. e.g. `pick(obj, ['a', 'b'], 'c')` becomes `pick(obj, 'a', 'b', 'c')`\

--- a/packages/object-safe-get/README.md
+++ b/packages/object-safe-get/README.md
@@ -1,6 +1,6 @@
 ## just-safe-get
 
-Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.  
+Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
 Guilt-free utilities for every occasion.
 
 [Try it now](http://anguscroll.com/just/just-safe-get)
@@ -22,8 +22,14 @@ get(obj.a, ['aa', 'aaa']); // 2
 get(obj.b, 'bb.bbb'); // undefined
 get(obj.b, ['bb', 'bbb']); // undefined
 
-get(null, 'a') // null
-get(undefined, 'a') //undefined
+get(obj.b, 'bb.bbb', 42); // 42
+get(obj.b, ['bb', 'bbb'], 42); // 42
+
+get(null, 'a'); // undefined
+get(undefined, ['a']); // undefined
+
+get(null, 'a', 42); // 42
+get(undefined, ['a'], 42); // 42
 
 const obj = {a: {}};
 const sym = Symbol();

--- a/packages/object-safe-get/index.js
+++ b/packages/object-safe-get/index.js
@@ -15,6 +15,15 @@ module.exports = get;
   get(obj.b, 'bb.bbb'); // undefined
   get(obj.b, ['bb', 'bbb']); // undefined
 
+  get(obj.b, 'bb.bbb', 42); // 42
+  get(obj.b, ['bb', 'bbb'], 42); // 42
+
+  get(null, 'a'); // undefined
+  get(undefined, ['a']); // undefined
+
+  get(null, 'a', 42); // 42
+  get(undefined, ['a'], 42); // 42
+
   const obj = {a: {}};
   const sym = Symbol();
   obj.a[sym] = 4;
@@ -23,7 +32,7 @@ module.exports = get;
 
 function get(obj, propsArg, defaultValue) {
   if (!obj) {
-    return obj;
+    return defaultValue;
   }
   var props, prop;
   if (Array.isArray(propsArg)) {

--- a/test/object-safe-get/index.js
+++ b/test/object-safe-get/index.js
@@ -137,10 +137,17 @@ test('follows empty keys using array arg', function(t) {
   t.end();
 });
 
-test('returns first argument if it is a falsey value', function(t) {
+test('returns undefined if first argument is a falsey value', function(t) {
   t.plan(2);
-  t.ok(compare(get(null, 'a'), null));
+  t.ok(compare(get(null, 'a'), undefined));
   t.ok(compare(get(undefined, 'a'), undefined));
+  t.end();
+});
+
+test('returns 3rd argument if first argument is a falsey value', function(t) {
+  t.plan(2);
+  t.ok(compare(get(null, 'a', 888), 888));
+  t.ok(compare(get(undefined, 'a', 888), 888));
   t.end();
 });
 


### PR DESCRIPTION
While updating our codebase from lodash, I found some more discrepancies due to missing support for 3rd param when 1st param is falsy. Updated it here and it's now lodash-compatible for those 4 cases:

```javascript
_.get(null, 'a'); // undefined
_.get(undefined, ['a']); // undefined
_.get(null, 'a', 42); // 42
_.get(undefined, ['a'], 42); // 42
```

However this change is probably breaking / semver-major:

```diff
-_.get(null, 'a'); // null
+_.get(null, 'a'); // undefined
```

Do you think it's okay to keep this, with the goal of better lodash compat?