### PR TITLE
make safe-set handle null values in props

### DIFF
--- a/packages/object-safe-set/index.js
+++ b/packages/object-safe-set/index.js
@@ -21,6 +21,10 @@ module.exports = set;
   const sym = Symbol();
   set(obj5.a, sym, 7); // true
   obj5; // {a: {Symbol(): 7}}
+
+  var obj6 = {a: null};
+  set(obj6, 'a.aa.aaa', 3); // true
+  obj6; // {a: {aa: {aaa: 3}}}
 */
 
 function set(obj, props, value) {
@@ -37,6 +41,9 @@ function set(obj, props, value) {
   var thisProp;
   while ((thisProp = props.shift())) {
     if (typeof obj[thisProp] == 'undefined') {
+      obj[thisProp] = {};
+    }
+    if (obj[thisProp] == null) {
       obj[thisProp] = {};
     }
     obj = obj[thisProp];

--- a/test/object-safe-set/index.js
+++ b/test/object-safe-set/index.js
@@ -46,6 +46,28 @@ test('sets non-existent property using array arg', function(t) {
   t.end();
 });
 
+test('sets null value property using dot-notation arg', function(t) {
+  t.plan(4);
+  var obj1 = {a: null};
+  t.isEqual(set(obj1, 'a.aa.aaa', 4), true);
+  t.ok(compare(obj1, {a: {aa: {aaa: 4}}}));
+  var obj2 = {a: null};
+  t.isEqual(set(obj2, 'a.aa', {bbb: 7}), true);
+  t.ok(compare(obj2, {a: {aa: {bbb: 7}}}));
+  t.end();
+});
+
+test('sets null value property using array arg', function(t) {
+  t.plan(4);
+  var obj1 = {a: null};
+  t.isEqual(set(obj1, ['a', 'aa', 'aaa'], 4), true);
+  t.ok(compare(obj1, {a: {aa: {aaa: 4}}}));
+  var obj2 = {a: null};
+  t.isEqual(set(obj2, ['a', 'aa'], {bbb: 7}), true);
+  t.ok(compare(obj2, {a: {aa: {bbb: 7}}}));
+  t.end();
+});
+
 test("doesn't interrupt property chain, using dot-notation arg", function(t) {
   t.plan(2);
   var obj1 = {a: 5};


### PR DESCRIPTION
First of all, thanks for the work on the library. It's been extremely useful to me over the years!

Regarding this PR, I would like to know what you think about the idea of handling `null` values in the provided props/path of `safe-set`. 

Currently, in case that one of the values in the object path will be null then the function will fail. My suggestion is that `safe-set` will handle `null` the same way it's handling `undefined` - instead of failing it will replace the value with an empty object literal and continue appending the rest of the path.

I'm assuming `null` values in the path was already been taken into account in the past, but I didn't find any discussion regarding this functionality, so I thought it's better to raise the discussion here with a PR (that might break existing usage, I'm aware of this, another approach might be a 4th boolean arg, e.g. `isNullable` or something like that).

Let me know if I can provide any other information, explanation, changes or whatever.

Thanks again.