### PR TITLE
remove redundant toLowerCase() in just-typeof

### DIFF
--- a/packages/object-typeof/index.js
+++ b/packages/object-typeof/index.js
@@ -27,5 +27,5 @@ function typeOf(obj) {
     .toLowerCase();
 
   // strip function adornments (e.g. "sAsyncFunction")
-  return result.toLowerCase().indexOf('function') > -1 ? 'function' : result;
+  return result.indexOf('function') > -1 ? 'function' : result;
 }


### PR DESCRIPTION
result should already be in lowercase, no need to lowercase it again