### PR TITLE
docs(number-clamp): fix example in comments

### DIFF
--- a/packages/number-clamp/index.js
+++ b/packages/number-clamp/index.js
@@ -3,7 +3,7 @@ module.exports = clamp;
 /*
   var n = 5;
   clamp(1, n, 12); // 5
-  clamp(12, n, 3); // 3
+  clamp(12, n, 3); // 5
   clamp(8.2, n, 9,4); // 8.2
   clamp(0, n, 0); // 0
 

--- a/test/number-clamp/index.js
+++ b/test/number-clamp/index.js
@@ -4,7 +4,7 @@ var clamp = require('../../packages/number-clamp');
 /*
   var n = 5;
   clamp(1, n, 12); // 5
-  clamp(12, n, 3); // 3
+  clamp(12, n, 3); // 5
   clamp(8.2, n, 9,4); // 8.2
   clamp(0, n, 0); // 0
 


### PR DESCRIPTION
When I first saw the example, it got me confused. I later realized it was a typo. Here is a fix.