### PR TITLE
feat: add object-safe-hasownproperty

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,38 @@ flip({ a: 1, b: 2, c: 3 }); // {'1': 'a', '2': 'b', '3': 'c'}
 flip({ a: false, b: true }); // {false: 'a', true: 'b'}
 ```
 
+### [just-has](https://www.npmjs.com/package/just-has)
+
+:icecream:[`Try It`](https://anguscroll.com/just/just-has)
+
+`npm install just-has`
+
+```js
+import has from "just-has";
+
+const obj = { a: { aa: { aaa: 2 } }, b: 4 };
+
+has(obj, "a.aa.aaa"); // true
+has(obj, ["a", "aa", "aaa"]); // true
+
+has(obj, "b.bb.bbb"); // false
+has(obj, ["b", "bb", "bbb"]); // false
+
+has(obj.a, "aa.aaa"); // true
+has(obj.a, ["aa", "aaa"]); // true
+
+has(obj.b, "bb.bbb"); // false
+has(obj.b, ["bb", "bbb"]); // false
+
+has(null, "a"); // false
+has(undefined, ["a"]); // false
+
+const obj = { a: {} };
+const sym = Symbol();
+obj.a[sym] = 4;
+has(obj.a, sym); // true
+```
+
 ### Arrays
 
 ### [just-unique](https://www.npmjs.com/package/just-unique)

--- a/packages/object-has/LICENSE
+++ b/packages/object-has/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 angus croll
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/object-has/README.md
+++ b/packages/object-has/README.md
@@ -1,0 +1,32 @@
+## just-has
+
+Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
+Guilt-free utilities for every occasion.
+
+[Try it now](http://anguscroll.com/just/just-has)
+
+```js
+import has from 'just-has';
+
+const obj = {a: {aa: {aaa: 2}}, b: 4};
+
+has(obj, 'a.aa.aaa'); // true
+has(obj, ['a', 'aa', 'aaa']); // true
+
+has(obj, 'b.bb.bbb'); // false
+has(obj, ['b', 'bb', 'bbb']); // false
+
+has(obj.a, 'aa.aaa'); // true
+has(obj.a, ['aa', 'aaa']); // true
+
+has(obj.b, 'bb.bbb'); // false
+has(obj.b, ['bb', 'bbb']); // false
+
+has(null, 'a'); // false
+has(undefined, ['a']); // false
+
+const obj = {a: {}};
+const sym = Symbol();
+obj.a[sym] = 4;
+has(obj.a, sym); // true
+```

--- a/packages/object-has/index.js
+++ b/packages/object-has/index.js
@@ -1,0 +1,64 @@
+module.exports = has;
+
+/*
+  const obj = {a: {aa: {aaa: 2}}, b: 4};
+
+  has(obj, 'a.aa.aaa'); // true
+  has(obj, ['a', 'aa', 'aaa']); // true
+
+  has(obj, 'b.bb.bbb'); // false
+  has(obj, ['b', 'bb', 'bbb']); // false
+
+  has(obj.a, 'aa.aaa'); // true
+  has(obj.a, ['aa', 'aaa']); // true
+
+  has(obj.b, 'bb.bbb'); // false
+  has(obj.b, ['bb', 'bbb']); // false
+
+  has(null, 'a'); // false
+  has(undefined, ['a']); // false
+
+  const obj = {a: {}};
+  const sym = Symbol();
+  obj.a[sym] = 4;
+  has(obj.a, sym); // true
+*/
+
+function has(obj, propsArg) {
+  if (!obj) {
+    return false;
+  }
+  var props, prop;
+  if (Array.isArray(propsArg)) {
+    props = propsArg.slice(0);
+  }
+  if (typeof propsArg == 'string') {
+    props = propsArg.split('.');
+  }
+  if (typeof propsArg == 'symbol') {
+    props = [propsArg];
+  }
+  if (!Array.isArray(props)) {
+    throw new Error('props arg must be an array, a string or a symbol');
+  }
+
+  while (props.length) {
+    prop = props.shift();
+
+    // if we are recursing, but met a nullish value, we cannot
+    // access it via .hasOwnProperty and should return negatively
+    if (obj == null) {
+      return false;
+    }
+    if (!Object.prototype.hasOwnProperty.call(obj, prop)) {
+      return false;
+    }
+    if (props.length === 0) {
+      return true;
+    }
+
+    obj = obj[prop];
+  }
+
+  return false;
+}

--- a/packages/object-has/package.json
+++ b/packages/object-has/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "just-has",
+  "version": "1.0.0",
+  "description": "return a boolen indicating the existence of a deep property, don't throw if parent is undefined",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "https://github.com/angus-c/just",
+  "keywords": [
+    "object",
+    "safe",
+    "hasownproperty",
+    "no-dependencies",
+    "just"
+  ],
+  "author": "Angus Croll",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angus-c/just/issues"
+  }
+}

--- a/test/object-has/index.js
+++ b/test/object-has/index.js
@@ -1,0 +1,112 @@
+var test = require('../util/test')(__filename);
+var has = require('../../packages/object-has');
+var compare = require('../../packages/collection-compare');
+
+test('returns existence of properties using dot-notation arg', function(t) {
+  t.plan(6);
+  var obj = {a: {aa: {aaa: 2}}, b: 0};
+  t.ok(compare(has(obj, 'a'), true));
+  t.ok(compare(has(obj, 'a.aa'), true));
+  t.ok(compare(has(obj, 'a.aa.aaa'), true));
+  t.ok(compare(has(obj, 'b'), true));
+  t.ok(compare(has(obj.a, 'aa'), true));
+  t.ok(compare(has(obj.a.aa, 'aaa'), true));
+  t.end();
+});
+
+test('returns existence of properties using array arg', function(t) {
+  t.plan(9);
+  var obj = {a: {aa: {aaa: 2}}, b: null};
+  t.ok(compare(has(obj, ['a']), true));
+  t.ok(compare(has(obj, ['a', 'aa']), true));
+  t.ok(compare(has(obj, ['a', 'aa', 'aaa']), true));
+  t.ok(compare(has(obj, ['b']), true));
+  t.ok(compare(has(obj.a, ['aa']), true));
+  t.ok(compare(has(obj.a.aa, ['aaa']), true));
+  var arr = ['a', 'aa', 'aaa'];
+  t.ok(compare(has(obj, arr), true));
+  t.ok(compare(arr, ['a', 'aa', 'aaa'])); // array arg preserved
+  t.ok(compare(obj, {a: {aa: {aaa: 2}}, b: null})); // obj arg preserved
+  t.end();
+});
+
+test('returns false for non-existing properties, using dot-notation arg', function(t) {
+  t.plan(7);
+  var obj = {a: {aa: {aaa: 2}}, b: 4, c: null, d: 0};
+  t.ok(compare(has(obj, 'b.bb'), false));
+  t.ok(compare(has(obj, 'a.bb'), false));
+  t.ok(compare(has(obj, 'a.aa.aaa.aaaa'), false));
+  t.ok(compare(has(obj, 'b.bb.bbb'), false));
+  t.ok(compare(has(obj.b, 'bb.bbb'), false));
+  t.ok(compare(has(obj, 'c.cc'), false));
+  t.ok(compare(has(obj, 'd.dd.ddd'), false));
+  t.end();
+});
+
+test('returns false for non-existing properties, using array arg', function(t) {
+  t.plan(9);
+  var obj = {a: {aa: {aaa: 2}}, b: 4, c: null, d: 0};
+  t.ok(compare(has(obj, ['b', 'bb']), false));
+  t.ok(compare(has(obj, ['a', 'bb']), false));
+  t.ok(compare(has(obj, ['b', 'bb', 'bbb']), false));
+  t.ok(compare(has(obj.b, ['bb', 'bbb']), false));
+  t.ok(compare(has(obj, ['c', 'cc']), false));
+  t.ok(compare(has(obj, ['d', 'dd', 'ddd']), false));
+  var arr = ['b', 'bb', 'bbb'];
+  t.ok(compare(has(obj, arr), false));
+  t.ok(compare(arr, ['b', 'bb', 'bbb'])); // array arg preserved
+  t.ok(compare(obj, {a: {aa: {aaa: 2}}, b: 4, c: null, d: 0})); // obj arg preserved
+
+  t.end();
+});
+
+test('returns false for falsey property names using dot notation', function(t) {
+  t.plan(5);
+  var obj = {a: {aa: {aaa: 2}}, b: {}};
+  t.ok(compare(has(obj, 'a.'), false));
+  t.ok(compare(has(obj, 'a.aa.aaa.'), false));
+  t.ok(compare(has(obj, 'b.'), false));
+  t.ok(compare(has(obj, 'b..b'), false));
+  t.ok(compare(has(obj, 'b...b'), false));
+  t.end();
+});
+
+test('returns false for falsey property names using array arg', function(t) {
+  t.plan(6);
+  var obj = {a: {aa: {aaa: 2}}, b: {'': {'': 3}}};
+  t.ok(compare(has(obj, ['a', false]), false));
+  t.ok(compare(has(obj, ['a', 'aa', 'aaa', null]), false));
+  t.ok(compare(has(obj, ['b', false]), false));
+  var arr = ['a', 'aa', 'aaa', null];
+  t.ok(compare(has(obj, arr), false));
+  t.ok(compare(arr, ['a', 'aa', 'aaa', null])); // array arg preserved
+  t.ok(compare(obj, {a: {aa: {aaa: 2}}, b: {'': {'': 3}}})); // obj arg preserved
+  t.end();
+});
+
+test('follows empty keys using array arg', function(t) {
+  t.plan(2);
+  var obj = {b: {'': {'': 3}}};
+  t.ok(compare(has(obj, ['b', '']), true));
+  t.ok(compare(has(obj, ['b', '', '']), true));
+  t.end();
+});
+
+test('returns false if first argument is a falsey value', function(t) {
+  t.plan(2);
+  t.ok(compare(has(null, 'a'), false));
+  t.ok(compare(has(undefined, 'a'), false));
+  t.end();
+});
+
+/* eslint-disable no-undef*/
+if (typeof Symbol === 'function') {
+  test('works with symbols', function(t) {
+    t.plan(1);
+    var obj = {a: {}};
+    var sym = Symbol();
+    obj.a[sym] = 4;
+    t.ok(compare(has(obj.a, sym), true));
+    t.end();
+  });
+}


### PR DESCRIPTION
Hi,

we often want to check just the existence on a deep object and avoid access prototypes or large data. For this purpose it would be cool to consider a .hasOwnProperty util.

Kind regards