### PR TITLE
Prototype pollution (Fixed)

### DIFF
--- a/packages/collection-diff-apply/index.js
+++ b/packages/collection-diff-apply/index.js
@@ -13,7 +13,6 @@ module.exports = {
     ]
   );
   obj1; // {a: 4, c: 5}
-
   // using converter to apply jsPatch standard paths
   // see http://jsonpatch.com
   import {diff, jsonPatchPathConverter} from 'just-diff'
@@ -24,7 +23,6 @@ module.exports = {
     { "op": "add", "path": '/c', "value": 5 }
   ], jsonPatchPathConverter);
   obj2; // {a: 4, c: 5}
-
   // arrays
   const obj3 = {a: 4, b: [1, 2, 3]};
   diffApply(obj3, [
@@ -33,7 +31,6 @@ module.exports = {
     { "op": "add", "path": ['b', 3], "value": 9 }
   ]);
   obj3; // {a: 3, b: [1, 2, 4, 9]}
-
   // nested paths
   const obj4 = {a: 4, b: {c: 3}};
   diffApply(obj4, [
@@ -80,6 +77,9 @@ function diffApply(obj, diff, pathConverter) {
     }
     var thisProp;
     while (((thisProp = pathCopy.shift())) != null) {
+      if (thisProp === '__proto__' || thisProp === 'constructor' || thisProp === 'prototype') {
+        throw new Error('Prototype pollution attempt detected');
+      }
       if (!(thisProp in subObject)) {
         subObject[thisProp] = {};
       }

--- a/packages/collection-diff-apply/index.js
+++ b/packages/collection-diff-apply/index.js
@@ -13,6 +13,7 @@ module.exports = {
     ]
   );
   obj1; // {a: 4, c: 5}
+
   // using converter to apply jsPatch standard paths
   // see http://jsonpatch.com
   import {diff, jsonPatchPathConverter} from 'just-diff'
@@ -23,6 +24,7 @@ module.exports = {
     { "op": "add", "path": '/c', "value": 5 }
   ], jsonPatchPathConverter);
   obj2; // {a: 4, c: 5}
+
   // arrays
   const obj3 = {a: 4, b: [1, 2, 3]};
   diffApply(obj3, [
@@ -31,6 +33,7 @@ module.exports = {
     { "op": "add", "path": ['b', 3], "value": 9 }
   ]);
   obj3; // {a: 3, b: [1, 2, 4, 9]}
+
   // nested paths
   const obj4 = {a: 4, b: {c: 3}};
   diffApply(obj4, [

--- a/packages/object-safe-set/index.js
+++ b/packages/object-safe-set/index.js
@@ -4,19 +4,15 @@ module.exports = set;
   var obj1 = {};
   set(obj1, 'a.aa.aaa', 4); // true
   obj1; // {a: {aa: {aaa: 4}}}
-
   var obj2 = {};
   set(obj2, ['a', 'aa', 'aaa'], 4); // true
   obj2; // {a: {aa: {aaa: 4}}}
-
   var obj3 = {a: {aa: {aaa: 2}}};
   set(obj3, 'a.aa.aaa', 3); // true
   obj3; // {a: {aa: {aaa: 3}}}
-
   // don't clobber existing
   var obj4 = {a: {aa: {aaa: 2}}};
   set(obj4, 'a.aa', {bbb: 7}); // false
-
   const obj5 = {a: {}};
   const sym = Symbol();
   set(obj5.a, sym, 7); // true
@@ -36,6 +32,9 @@ function set(obj, props, value) {
   }
   var thisProp;
   while ((thisProp = props.shift())) {
+    if (thisProp === '__proto__' || thisProp === 'constructor' || thisProp === 'prototype') {
+      return false;
+    }
     if (typeof obj[thisProp] == 'undefined') {
       obj[thisProp] = {};
     }

--- a/packages/object-safe-set/index.js
+++ b/packages/object-safe-set/index.js
@@ -4,15 +4,19 @@ module.exports = set;
   var obj1 = {};
   set(obj1, 'a.aa.aaa', 4); // true
   obj1; // {a: {aa: {aaa: 4}}}
+
   var obj2 = {};
   set(obj2, ['a', 'aa', 'aaa'], 4); // true
   obj2; // {a: {aa: {aaa: 4}}}
+
   var obj3 = {a: {aa: {aaa: 2}}};
   set(obj3, 'a.aa.aaa', 3); // true
   obj3; // {a: {aa: {aaa: 3}}}
+
   // don't clobber existing
   var obj4 = {a: {aa: {aaa: 2}}};
   set(obj4, 'a.aa', {bbb: 7}); // false
+
   const obj5 = {a: {}};
   const sym = Symbol();
   set(obj5.a, sym, 7); // true


### PR DESCRIPTION
This package is vulnerable to ```prototype pollution```.
POC
```javascript
var {diffApply} = require("./packages/collection-diff-apply/")
var obj = {}
const patch = [{op: "add", path: ["__proto__","polluted"], value: "Yes! Its Polluted"}];
console.log("Before : " + obj.polluted);
diffApply(obj, patch);
var obj1={}
console.log("After : " + obj1.polluted);
```
Output
```
Before : undefined
After : Yes! Its Polluted
```
After fix no prototype pollution.