### PR TITLE
improve the examples and the tests for array-split

### DIFF
--- a/packages/array-split/index.js
+++ b/packages/array-split/index.js
@@ -3,12 +3,13 @@ module.exports = split;
 /*
     split([]); // []
     split([1, 2, 3, 4, 5]); // [[1, 2, 3, 4, 5]]
+    split([1, 2, 3, 4, 5], null); // [[1, 2, 3, 4, 5]]
     split([1, 2, 3, 4, 5, 6, 7, 8, 9], 3); // [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     split(['a', 'b', 'c', 'd', 'e'], 2); // [['a', 'b'], ['c', 'd'], ['e']]
     split([1, 2, 3, 4, 5, 6, 7, 8], 3); // [[1, 2, 3], [4, 5, 6], [7, 8]]
     split(null, 3); // throws
     split([1, 2, 3, 4, 5, 6], '3'); // throws
-    split([1, 2, 3, 4, 5, 6], null); // throws
+    split([1, 2, 3, 4, 5, 6], {}); // throws
 */
 
 function split(arr, n) {
@@ -16,7 +17,7 @@ function split(arr, n) {
     throw new Error('expected an array for the first argument');
   }
   if (n != null && typeof n != 'number') {
-    throw new Error('expected a number or null for the second argument');
+    throw new Error('expected a number or null/undefined for the second argument');
   }
   n = n != null ? n : arr.length;
   var len = arr.length;

--- a/test/array-split/index.js
+++ b/test/array-split/index.js
@@ -16,6 +16,13 @@ test('if only array is passed as argument, treat n as the length of array', func
   t.end();
 });
 
+test('if second argument is null, treat n as the length of array', function(t) {
+  t.plan(2);
+  t.deepEqual(split([1, 2, 3, 4, 5, 6, 7, 8, 9], null), [[1, 2, 3, 4, 5, 6, 7, 8, 9]]);
+  t.deepEqual(split([100, 100, 100, 200, 300, 400], null), [[100, 100, 100, 200, 300, 400]]);
+  t.end();
+});
+
 test('splits array into groups of n size if array length divisible by n', function(t) {
   t.plan(2);
   t.deepEqual(split([1, 2, 3, 4, 5, 6, 7, 8, 9], 3), [[1, 2, 3], [4, 5, 6], [7, 8, 9]]);


### PR DESCRIPTION
- Correct the result of the example `split([1, 2, 3, 4, 5, 6], null)`. It returns an array of the same elements as the first argument and does not throw an error.
- Add tests for the above example.
- Change the second error message to more accurate expression.
