### PR TITLE
Fix number-is-prime logic

### DIFF
--- a/packages/number-is-prime/README.md
+++ b/packages/number-is-prime/README.md
@@ -3,6 +3,8 @@
 Part of a [library](../../../../) of zero-dependency npm modules that do just do one thing.
 Guilt-free utilities for every occasion.
 
+[Try it now](https://anguscroll.com/just/just-is-prime)
+
 ```
   import isPrime from 'just-is-prime;
 

--- a/packages/number-is-prime/index.js
+++ b/packages/number-is-prime/index.js
@@ -22,7 +22,7 @@ function isPrime(number) {
     return false;
   }
 
-  for (var i = 2; i < Math.sqrt(number); i++) {
+  for (var i = 2; i <= Math.sqrt(number); i++) {
     if (number % i === 0) {
       return false;
     }

--- a/test/number-is-prime/index.js
+++ b/test/number-is-prime/index.js
@@ -10,9 +10,10 @@ test('number is prime', function(t) {
 });
 
 test('number is not prime', function(t) {
-  t.plan(5);
+  t.plan(6);
   t.notOk(isPrime(0));
   t.notOk(isPrime(1));
+  t.notOk(isPrime(4));
   t.notOk(isPrime(10));
   t.notOk(isPrime(-10));
   t.notOk(isPrime(13440));


### PR DESCRIPTION
When a given number is a square of prime, the function returns `true` while the number is composite.

[the sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)

- Fix the bug. 
- Add a test for square of prime.
- Add `Try it now` link to README.