### PR TITLE
Add polyfills for some ES6 Number methods

### DIFF
--- a/packages/array-mean/index.js
+++ b/packages/array-mean/index.js
@@ -1,5 +1,11 @@
 module.exports = mean;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 function mean(arr) {
   if (!Array.isArray(arr)) {
     arr = [].slice.call(arguments);

--- a/packages/array-median/index.js
+++ b/packages/array-median/index.js
@@ -1,5 +1,11 @@
 module.exports = median;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 var nonNumericMsg = 'all values passed to `median` must be numeric';
 
 function median(arr) {

--- a/packages/array-median/index.js
+++ b/packages/array-median/index.js
@@ -23,7 +23,7 @@ function median(arr) {
     }
   }
   var sorted = arr.sort(function(a, b) {
-    if (typeof a != 'number') {
+    if (!Number.isFinite(a)) {
       throw new Error(nonNumericMsg);
     }
     return a >= b ? 1 : -1;

--- a/packages/array-mode/index.js
+++ b/packages/array-mode/index.js
@@ -1,5 +1,11 @@
 module.exports = mode;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 function mode(arr) {
   if (!Array.isArray(arr)) {
     arr = [].slice.call(arguments);

--- a/packages/array-percentile/index.js
+++ b/packages/array-percentile/index.js
@@ -1,5 +1,11 @@
 module.exports = percentile;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 var nonNumericMsg = 'all values passed to `percentile` must be numeric';
 
 // Using linear interpolation method

--- a/packages/array-skewness/index.js
+++ b/packages/array-skewness/index.js
@@ -1,5 +1,11 @@
 module.exports = skewness;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 function skewness(arr) {
   if (!Array.isArray(arr)) {
     arr = [].slice.call(arguments);

--- a/packages/array-stdev/index.js
+++ b/packages/array-stdev/index.js
@@ -1,5 +1,11 @@
 module.exports = stdev;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 function stdev(arr) {
   if (!Array.isArray(arr)) {
     arr = [].slice.call(arguments);

--- a/packages/array-variance/index.js
+++ b/packages/array-variance/index.js
@@ -1,5 +1,11 @@
 module.exports = variance;
 
+if (Number.isFinite === undefined) {
+  Number.isFinite = function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+}
+
 function variance(arr) {
   if (!Array.isArray(arr)) {
     arr = [].slice.call(arguments);

--- a/packages/number-is-prime/index.js
+++ b/packages/number-is-prime/index.js
@@ -13,6 +13,12 @@ module.exports = isPrime;
   isPrime([]); // throws
 */
 
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value;
+};
+
 function isPrime(number) {
   if (!Number.isInteger(number)) {
     throw new Error('just-is-prime expects an integer argument');

--- a/test/array-median/index.js
+++ b/test/array-median/index.js
@@ -24,9 +24,12 @@ test('array of numbers (length is even) returns mean of middle 2 sorted values',
 });
 
 test('non-numeric values throw', function(t) {
-  t.plan(3);
+  t.plan(4);
   t.throws(function() {
     median([1, '2', 3, 4, 5]);
+  });
+  t.throws(function() {
+    median([1, NaN, 3, 4, 5]);
   });
   t.throws(function() {
     median({a: 2}, {b: 3});


### PR DESCRIPTION
`Number.isFinite` and `Number.isInteger` are not in ES5 specification and IE11 [does not support them](https://caniuse.com/?search=Number%3A%20is). So I add polyfills for those ([Number.isFinite](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#Polyfill), [Number.isInteger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill)).  