### PR TITLE
add ts types for array split

### DIFF
--- a/packages/array-split/index.d.ts
+++ b/packages/array-split/index.d.ts
@@ -1,0 +1,3 @@
+declare function split<T>(arr: T[], n?: number): Array<T[]>;
+
+export = split;

--- a/packages/array-split/index.d.ts
+++ b/packages/array-split/index.d.ts
@@ -1,3 +1,1 @@
-declare function split<T>(arr: T[], n?: number): Array<T[]>;
-
-export = split;
+export default function split<T>(arr: T[], n?: number): Array<T[]>

--- a/packages/array-split/index.tests.ts
+++ b/packages/array-split/index.tests.ts
@@ -1,0 +1,34 @@
+import split from './index'
+
+split([]); // []
+split([1, 2, 3, 4, 5]); // [[1, 2, 3, 4, 5]]
+split([1, 2, 3, 4, 5], null); // [[1, 2, 3, 4, 5]]
+split([1, 2, 3, 4, 5, 6, 7, 8, 9], 3); // [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+split(['a', 'b', 'c', 'd', 'e'], 2); // [['a', 'b'], ['c', 'd'], ['e']]
+split([1, 2, 3, 4, 5, 6, 7, 8], 3); // [[1, 2, 3], [4, 5, 6], [7, 8]]
+
+// return types should match input type
+const numberArray = split([1, 2, 3, 4, 5]); // [[1, 2, 3, 4, 5]]
+numberArray[0][0] = 1;
+numberArray[0] = [7,8,9];
+// @ts-expect-error
+numberArray[0][0] = 'a';
+// @ts-expect-error
+numberArray[0] = ['a','b','c'];
+
+// mixed return types should match the input array type
+type MixedArray = Array<string | number | {s: string, n: number}>;
+const mixedArray : MixedArray = ['a',1, {s: 'b', n: 2}];
+const splitMixedArray = split(mixedArray, 2);
+splitMixedArray[0].push(3);
+splitMixedArray[0].push('c');
+splitMixedArray[0].push({s: 'd', n: 4});
+// @ts-expect-error
+splitMixedArray[0].push({s: 5});
+
+// not OK
+split(null, 3); // throws
+// @ts-expect-error
+split([1, 2, 3, 4, 5, 6], '3'); // throws
+// @ts-expect-error
+split([1, 2, 3, 4, 5, 6], {}); // throws


### PR DESCRIPTION
This adds types for array split.  

## Notes

For `split(null)` I couldn't get this to work without `strictNullChecks`.  `NonNullable<T[]>` also didn't work.  

Still, these types improve upon the existing return types by inferring the from the type passed in.