### PR TITLE
Add an npm script to run tests for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && tape ./test/**/index.js | tap-spec"
+    "test": "npm run lint && tape ./test/**/index.js | tap-spec; npm run test:type",
+    "test:type": "tsc packages/**/*.tests.ts --noEmit --strictNullChecks"
   },
   "repository": {
     "type": "git",

--- a/packages/array-split/index.d.ts
+++ b/packages/array-split/index.d.ts
@@ -1,1 +1,1 @@
-export default function split<T>(arr: T[], n?: number): Array<T[]>
+export default function split<T>(arr: T[], n?: number | null): Array<T[]>

--- a/packages/array-split/index.tests.ts
+++ b/packages/array-split/index.tests.ts
@@ -27,6 +27,7 @@ splitMixedArray[0].push({s: 'd', n: 4});
 splitMixedArray[0].push({s: 5});
 
 // not OK
+// @ts-expect-error
 split(null, 3); // throws
 // @ts-expect-error
 split([1, 2, 3, 4, 5, 6], '3'); // throws


### PR DESCRIPTION
- Add `npm run test:type` command.
- Add the command in `test` script.
- Fix type test of array-spilit, for the function actually accepts `null` as its second argument.