### PR TITLE
Temporarily removing `Array.prototype.flatten` override

### DIFF
--- a/packages/array-flatten/index.js
+++ b/packages/array-flatten/index.js
@@ -33,9 +33,9 @@ function flatten(arr, depth) {
 
   var optionDepth = typeof depth === 'number' ? depth : Infinity;
 
-  if (Array.prototype.flat) {
-    return arr.flat(optionDepth);
-  }
+  // if (Array.prototype.flat) {
+  //   return arr.flat(optionDepth);
+  // }
 
   return flattenHelper(arr, optionDepth);
 }

--- a/test/array-flatten/index.js
+++ b/test/array-flatten/index.js
@@ -3,8 +3,8 @@
 var test = require('../util/test')(__filename);
 var flatten = require('../../packages/array-flatten');
 
-var protoFlat = Array.prototype.flat;
-Array.prototype.flat = null;
+// var protoFlat = Array.prototype.flat;
+// Array.prototype.flat = null;
 
 test('flattened arrays are unchanged', function(t) {
   t.plan(1);
@@ -76,4 +76,4 @@ test('throws when depth is not a number', function(t) {
   t.end();
 });
 
-Array.prototype.flat = protoFlat;
+// Array.prototype.flat = protoFlat;


### PR DESCRIPTION
When removing the override in array-flatten test, other tests are broken (`collection-clone` and `collection-diff-apply`)