### PR TITLE
Add type definition for array-group-by

### DIFF
--- a/packages/array-group-by/index.d.ts
+++ b/packages/array-group-by/index.d.ts
@@ -1,0 +1,6 @@
+type PropertyKey = string | symbol
+type Stringifyable = {
+  toString: () => string
+}
+
+export default function groupBy<T>(arr: T[], cb: (arg: T) => Stringifyable): { [key in PropertyKey]: T[] }

--- a/packages/array-group-by/index.tests.ts
+++ b/packages/array-group-by/index.tests.ts
@@ -1,0 +1,44 @@
+import groupBy from './index'
+
+// OK
+const test1: { [key: string]: number[] } = groupBy([6.1, 4.2, 6.3], Math.floor);
+const test2: { [key: string]: string[] } = groupBy(['a', 'b', 'c', 'aa', 'bb', 'cc'], str => str.charAt(0));
+const test3: { [key: string]: number[][] } = groupBy([[1], [2], [1, 2]], arr => arr.length);
+const test4: {} = groupBy([], () => "a");
+const test5: { [key: string]: (number | string)[] } = groupBy([1, 2, 3, "1", "2"], parseInt);
+const test6 = groupBy(['a', 'b', 'c'], str => Symbol(str));
+
+// Not OK
+// @ts-expect-error
+groupBy();
+
+// First argument must be an array.
+// @ts-expect-error
+groupBy({}, Math.floor);
+// @ts-expect-error
+groupBy('hello', Math.floor);
+// @ts-expect-error
+groupBy(/hullo/, Math.floor);
+// @ts-expect-error
+groupBy(null, Math.floor);
+// @ts-expect-error
+groupBy(undefined, Math.floor);
+
+// @ts-expect-error
+groupBy(["a", "b", "c"], () => { });
+// @ts-expect-error
+groupBy(["a", "b", "c"], Math.floor);
+// @ts-expect-error
+groupBy(["a", "b", "c"], () => null);
+// @ts-expect-error
+groupBy([], {});
+// @ts-expect-error
+groupBy([], []);
+// @ts-expect-error
+groupBy([], /hullo/);
+// @ts-expect-error
+groupBy([], null);
+// @ts-expect-error
+groupBy([], undefined);
+// @ts-expect-error
+groupBy([]);


### PR DESCRIPTION
Add a type definition and tests for [array-group-by](https://github.com/angus-c/just/blob/master/packages/array-group-by/index.js).