### PR TITLE
Add typings for object-merge

### DIFF
--- a/packages/object-merge/index.d.ts
+++ b/packages/object-merge/index.d.ts
@@ -1,0 +1,3 @@
+// Definitions by: nokazn <https://github.com/nokazn>
+declare function merge(obj1: object, ...objs: object[]): object;
+export = merge;

--- a/packages/object-merge/index.tests.ts
+++ b/packages/object-merge/index.tests.ts
@@ -1,0 +1,54 @@
+import merge = require('./index');
+
+// OK
+
+// Single argument
+merge({});
+merge({ a: 1 });
+merge([]);
+merge(() => {});
+merge(new Map());
+merge(new Set());
+
+// Multiple arguments
+merge({}, {});
+merge({}, { a: 1 });
+merge({}, []);
+merge({}, () => {});
+merge({}, new Map());
+merge({}, new Set());
+merge({}, { a: 1 }, { a: 2, b: 3 });
+
+// Not OK
+
+// Single argument
+// @ts-expect-error
+merge();
+// @ts-expect-error
+merge(0);
+// @ts-expect-error
+merge('');
+// @ts-expect-error
+merge(false);
+// @ts-expect-error
+merge(null);
+// @ts-expect-error
+merge(undefined);
+// @ts-expect-error
+merge(Symbol());
+
+// Multiple arguments
+// @ts-expect-error
+merge({}, 0);
+// @ts-expect-error
+merge({}, '');
+// @ts-expect-error
+merge({}, false);
+// @ts-expect-error
+merge({}, null);
+// @ts-expect-error
+merge({}, undefined);
+// @ts-expect-error
+merge({}, Symbol());
+// @ts-expect-error
+merge({}, {}, null);

--- a/packages/object-merge/package.json
+++ b/packages/object-merge/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "shallow extend an object",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I copied these typings from the DefinitelyTyped repository.

<hr>

I [opened a PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52729) to remove this project's typings from the DefinitelyTyped repository and noticed that the "just-merge" typings didn't make it over here yet. If this PR lands, I can finish removing all of the "just" typings from that repo.