### PR TITLE
Add type definitions for object-filter package

### DIFF
--- a/packages/object-filter/index.d.ts
+++ b/packages/object-filter/index.d.ts
@@ -1,0 +1,9 @@
+type PlainObject<T> = T extends Map<any, any> | Set<any> | null ? never :
+  T extends object ? T :
+  never;
+
+declare function filter<T>(
+  obj: PlainObject<T>,
+  fn: (key: keyof T, value: T[typeof key]) => any
+): Partial<T>;
+export = filter;

--- a/packages/object-filter/index.tests.ts
+++ b/packages/object-filter/index.tests.ts
@@ -1,0 +1,27 @@
+import filter = require('./index');
+
+// OK
+filter({a: 5}, (_key: string, _val: number) => true);
+filter({a: 5, b: "c"}, (_key: string, _val: string|number) => true);
+filter({a: 5, b: "c"}, (_key: 'a'|'b', _val: string|number) => true);
+filter({a: 5, b: "c"}, (_key: 'a'|'b'|'c', _val: string|number) => true);
+
+
+// Not OK
+// @ts-expect-error
+filter(5, (_key: string, _val: number) => "a");
+// @ts-expect-error
+filter(null, (_key: string, _val: number) => "a");
+// @ts-expect-error
+filter(true, (_key: string, _val: number) => "a");
+// @ts-expect-error
+filter({ a: 5 })
+// @ts-expect-error
+filter({ a: 5 }, (_key: string, _val: number) => true, 10);
+// @ts-expect-error
+filter(['a', 'b', 'c'], (_key: string, _val: number) => true);
+// @ts-expect-error
+filter(new Set(), (_key: string, _val: number) => true);
+// @ts-expect-error
+filter(new Map(), (_key: string, _val: number) => true);
+

--- a/packages/object-filter/package.json
+++ b/packages/object-filter/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "filter an object",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
A bit of type gymnastics here to cause an error when passing in a Set or Map, but otherwise not too complex.