### PR TITLE
Make throttle type generic

### DIFF
--- a/packages/function-throttle/index.d.ts
+++ b/packages/function-throttle/index.d.ts
@@ -11,6 +11,6 @@ type Methods = {
   flush: () => void,
 }
 
-declare function throttle(fn: Function, interval: number, options?: options): Function & Methods;
+declare function throttle<Func extends (...args: any[]) => any>(fn: Func, interval: number, options?: options): Func & Methods;
 
 export = throttle;


### PR DESCRIPTION
### Why?

Currently `just/throttle` returns `Function & Methods`, which is not safe nor assignable to `addEventListener`.

![スクリーンショット 2021-06-02 14 58 08](https://user-images.githubusercontent.com/5250706/120431090-f8c22480-c3b2-11eb-955a-73de6d051284.png)

TypeScript doc says...

> This is an untyped function call and is generally best avoided because of the unsafe any return type.
> If you need to accept an arbitrary function but don’t intend to call it, the type () => void is generally safer.

### What this PR changes

Use generic function type instead, which will improve type safety and make it easier to use.

Since generic `Func` is inferred from the parameter, we are not forced to write like `throttle<() => void>`. So this PR would not be a breaking change.
