### PR TITLE
replace 3 period approximation with correct ellipsis character

### DIFF
--- a/packages/string-truncate/index.js
+++ b/packages/string-truncate/index.js
@@ -13,7 +13,7 @@ function truncate(str, length, end) {
     return str;
   }
   if (end == null) {
-    end = ' … ';
+    end = '…';
   }
   return str.slice(0, Math.max(0, length - end.length)) + end;
 }

--- a/packages/string-truncate/index.js
+++ b/packages/string-truncate/index.js
@@ -13,7 +13,7 @@ function truncate(str, length, end) {
     return str;
   }
   if (end == null) {
-    end = '...';
+    end = '…';
   }
   return str.slice(0, Math.max(0, length - end.length)) + end;
 }

--- a/packages/string-truncate/index.js
+++ b/packages/string-truncate/index.js
@@ -13,7 +13,7 @@ function truncate(str, length, end) {
     return str;
   }
   if (end == null) {
-    end = '…';
+    end = ' … ';
   }
   return str.slice(0, Math.max(0, length - end.length)) + end;
 }

--- a/test/string-truncate/index.js
+++ b/test/string-truncate/index.js
@@ -5,7 +5,7 @@ test('string defaulted with default suffix', function(t) {
   t.plan(1);
   var str = 'when shall we three meet again';
   var result = truncate(str, 9);
-  t.equal(result, 'when s … ');
+  t.equal(result, 'when s…');
   t.end();
 });
 

--- a/test/string-truncate/index.js
+++ b/test/string-truncate/index.js
@@ -5,7 +5,7 @@ test('string defaulted with default suffix', function(t) {
   t.plan(1);
   var str = 'when shall we three meet again';
   var result = truncate(str, 9);
-  t.equal(result, 'when s...');
+  t.equal(result, 'when s … ');
   t.end();
 });
 


### PR DESCRIPTION
Small typographic refinement that anything functional.

Replaces the 3 periods _..._ approximation in the `truncate` method with the single typographic _…_ character. 

Saves a small amount of real-estate when used + marginally less characters in the codebase