### PR TITLE
Updated strategy for consecutive caps, recognize international letters, fix default truncate suffix

### DIFF
--- a/packages/string-kebab-case/index.js
+++ b/packages/string-kebab-case/index.js
@@ -14,24 +14,20 @@ module.exports = kebabCase;
 // any combination of spaces and punctuation characters
 // thanks to http://stackoverflow.com/a/25575009
 var wordSeparators = /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+/;
-var capitals_plus_lower = /[A-Z\u00C0-\u00D6\u00D9-\u00DD]+[a-z]/g;
-var capitals_plus_other = /[A-Z\u00C0-\u00D6\u00D9-\u00DD]+[$|^a-zA-Z]/g;
+var capital_plus_lower = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD][a-zà-ÿ]/g;
+var capitals = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD]+/g;
 
 function kebabCase(str) {
-  //replace consecutive caps of caps with space + lower case equivalent for later parsing
-  str = str.replace(capitals_plus_lower, function(match) {
-    // match is consecutive caps followed by one non-cap
-    console.log('***** match', match);
-    var lastChar = match[match.length - 1];
-    var lastCapLowered = match[match.length - 2].toLowerCase();
-    var leadingChars = '';
-    if (match.length > 2) {
-      var leadingChars = ' ' + match.slice(0, match.length - 2).toLowerCase();
-    }
-    return leadingChars + ' ' + lastCapLowered + lastChar;
+  // replace word starts with space + lower case equivalent for later parsing
+  // 1) treat cap + lower as start of new word
+  str = str.replace(capital_plus_lower, function(match) {
+    // match is one caps followed by one non-cap
+    return ' ' + (match[0].toLowerCase() || match[0]) + match[1];
   });
-  str = str.replace(capitals_plus_other, function(match) {
-    return match.toLowerCase();
+  // 2) treat all remaining capitals as words
+  str = str.replace(capitals, function(match) {
+    // match is a series of caps
+    return ' ' + match.toLowerCase();
   });
   return str
     .trim()

--- a/packages/string-kebab-case/package.json
+++ b/packages/string-kebab-case/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-kebab-case",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "convert a string to kebab case",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/string-truncate/index.js
+++ b/packages/string-truncate/index.js
@@ -13,7 +13,7 @@ function truncate(str, length, end) {
     return str;
   }
   if (end == null) {
-    end = '…';
+    end = '...';
   }
   return str.slice(0, Math.max(0, length - end.length)) + end;
 }

--- a/packages/string-truncate/package.json
+++ b/packages/string-truncate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-truncate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "truncate a string with a custom suffix",
   "main": "index.js",
   "scripts": {

--- a/test/string-kebab-case/index.js
+++ b/test/string-kebab-case/index.js
@@ -25,11 +25,14 @@ test('string with mixed spaces and punctuation', function(t) {
 });
 
 test('string with capitalization', function(t) {
-  t.plan(4);
+  t.plan(8);
   t.equal(kebabCase('theQuickBrownFox'), 'the-quick-brown-fox');
   t.equal(kebabCase('the QuickBrown Fox'), 'the-quick-brown-fox');
   t.equal(kebabCase('The quick brown FOX'), 'the-quick-brown-fox');
   t.equal(kebabCase('MapGLBeta'), 'map-gl-beta');
-  t.equal(kebabCase('MapGLB-_-eta'), 'map-gl-beta');
+  t.equal(kebabCase('MapGL-_-Beta'), 'map-gl-beta');
+  t.equal(kebabCase('MapGL-_-beta'), 'map-gl-beta');
+  t.equal(kebabCase('ABCHaček Kroužek'), 'abc-haček-kroužek');
+  t.equal(kebabCase('Bonjour XYZÉtienne-Louis Boullée'), 'bonjour-xyz-étienne-louis-boullée');
   t.end();
 });

--- a/test/string-truncate/index.js
+++ b/test/string-truncate/index.js
@@ -5,7 +5,7 @@ test('string defaulted with default suffix', function(t) {
   t.plan(1);
   var str = 'when shall we three meet again';
   var result = truncate(str, 9);
-  t.equal(result, 'when s…');
+  t.equal(result, 'when s...');
   t.end();
 });
 


### PR DESCRIPTION
1) Treat consecutive caps as a word, but break word on last cap if next letter is lower case
2) Add non-english upper and lower case letters to regex
3) Replace elipse with '...' for truncate suffix (some editor magic mush have converted it)