### PR TITLE
changed percentile algorithm

### DIFF
--- a/packages/array-percentile/index.d.ts
+++ b/packages/array-percentile/index.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Finds the score that is required to be above a percentile of a distribution of scores. Uses R7 formula described in the [nist spec](https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm)
+ *
+ * For example, the 50th percentile is the score at which 50% of the distribution is less than the value
+ *
+ * @param arr The distibution of values
+ * @param percentage The fractional percentage
+ * @example
+ * percentile([1, 2, 3], 0.0); // => 1
+ * percentile([1, 2, 3], 0.5); // => 2
+ * percentile([1, 2, 3], 1.0); // => 3
+ * percentile([15, 20, 35, 40, 50], .40); // => 26
+ */
+export default function percentile(arr: number[], percentage: number): number

--- a/packages/array-percentile/index.js
+++ b/packages/array-percentile/index.js
@@ -1,42 +1,41 @@
 module.exports = percentile;
 
-var nonNumericMsg = 'all values passed to `percentile` must be numeric';
+var numericError = 'all values passed to percentile must be numeric'
 
-// Using linear interpolation method
-// https://en.wikipedia.org/wiki/Percentile
-
-function percentile(arr, percentileValue) {
+// Percentile (Exlusive) from the nist spec
+function percentile(arr, percentage) {
   if (!Array.isArray(arr)) {
-    throw new Error('the argument to `percentile` must be an array');
+    throw new Error('the first argument to percentile must be an array');
+  }
+  if (percentage < 0 || percentage > 1) {
+    throw new Error('The percent must be between 0 and 1');
   }
   if (!arr.length) {
-    throw new Error('no values were passed to `percentile`');
+    throw new Error('no values were passed to percentile');
   }
-  if (arr.length == 1) {
-    if (Number.isFinite(arr[0])) {
-      return arr[0];
-    } else {
-      throw new Error(nonNumericMsg);
-    }
+  //sort doesnt call if length is one. need to check explicitly.
+  if (arr.length === 1 && !Number.isFinite(arr[0])) {
+    throw new Error(numericError)
   }
   var sorted = arr.sort(function(a, b) {
     if (!Number.isFinite(a)) {
-      throw new Error(nonNumericMsg);
+      throw new Error(numericError);
     }
-    return a >= b ? 1 : -1;
+    return a - b;
   });
-  var percentileRank = Math.min(
-    Math.max((arr.length * percentileValue) / 100 - 0.5, 0),
-    arr.length - 1
-  );
-  var lowerInt = Math.floor(percentileRank);
-  if (percentileRank == lowerInt) {
-    return sorted[lowerInt];
-  } else {
-    var upperInt = Math.ceil(percentileRank);
-    return (
-      sorted[lowerInt] +
-      (percentileRank - lowerInt) * (sorted[upperInt] - sorted[lowerInt])
-    );
+
+  var rank = percentage * (arr.length - 1) + 1;
+  var rankInt = Math.floor(rank);
+  var rankFrac = rank - rankInt;
+
+  if(rank === 0) {
+    return arr[0];
   }
+  if(rank >= arr.length) {
+    return arr[arr.length - 1];
+  }
+
+  var upper = sorted[rankInt];
+  var lower = sorted[rankInt - 1];
+  return (lower + rankFrac * (upper - lower));
 }

--- a/packages/array-percentile/index.tests.ts
+++ b/packages/array-percentile/index.tests.ts
@@ -1,0 +1,30 @@
+import percentile from "./index"
+
+//Ok
+var a: number = percentile([1, 2, 3, 4, 5], 0.15)
+percentile([5, 4, 1, 3, 2], 0.35)
+percentile([1, 2, 3, 4, 5], 0.44)
+percentile([100, 101, 92, 4, 102, 66, 66], 0.65)
+percentile([100, 101, 92, 4, 102, 32], 0.50)
+
+
+//Ok but throws errors
+percentile([], 0.50)
+percentile([], 1.5)
+
+
+// @ts-expect-error
+percentile(1, 2, 3, 4, 5, 0.50);
+
+// @ts-expect-error
+percentile(1, 0.50);
+
+
+// @ts-expect-error
+percentile([1, '2', 3, 4, 5], 0.50);
+// @ts-expect-error
+percentile([false, true], 0.66);
+// @ts-expect-error
+percentile(undefined, 0.66);
+// @ts-expect-error
+percentile(null, 0.40);

--- a/packages/array-percentile/package.json
+++ b/packages/array-percentile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-percentile",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "return the value at the given percentile (using linear interpolation)",
   "main": "index.js",
   "scripts": {

--- a/test/array-percentile/index.js
+++ b/test/array-percentile/index.js
@@ -2,40 +2,54 @@ var test = require('../util/test')(__filename);
 var percentile = require('../../packages/array-percentile');
 
 test('array of numbers where percentile falls exactly on an index', function(t) {
-  t.plan(5);
-  t.equal(percentile([1, 2, 3, 4, 5], 30), 2);
-  t.equal(percentile([1, 5, 2, 4, 3], 50), 3);
-  t.equal(percentile([5, 4, 1, 3, 2], 70), 4);
-  t.equal(percentile([1, 1, 1, 1, 1], 17), 1);
-  t.equal(percentile([-4.2, -4.2, -4.2, -4.2, -4.2], 67), -4.2);
+  t.plan(6);
+  var dataset = [5, 4, 1, 3, 2]
+  t.equal(percentile(dataset, 0), 1);
+  t.equal(percentile(dataset, 0.25), 2);
+  t.equal(percentile(dataset, 0.5), 3);
+  t.equal(percentile(dataset, 0.75), 4);
+  t.equal(percentile([1, 1, 1, 1, 1], 0.17), 1);
+  t.equal(percentile([-4.2, -4.2, -4.2, -4.2, -4.2], 0.67), -4.2);
   t.end();
 });
 
 test('array of numbers where percentile falls outside outer bounds', function(t) {
   t.plan(3);
-  t.equal(percentile([0.1, 2, 93, 14.98, 7], 4), 0.1);
-  t.equal(percentile([0.1, 2, 93, 14.98, 7], 94), 93);
-  t.equal(percentile([44, -2.91, 7, 7, -2.91], 3), -2.91);
+  t.equal(percentile([0.1, 2, 93, 14.98, 7], 0.4), 5);
+  t.equal(percentile([0.1, 2, 93, 14.98, 7], 0.94).toFixed(3), '74.275');
+  t.equal(percentile([44, -2.91, 7, 7, -2.91], 0.3).toFixed(3), '-0.928');
   t.end();
 });
 
 test('array of numbers where percentile falls between indices', function(t) {
   t.plan(5);
-  t.equal(percentile([1, 2, 3, 4, 5], 25), 1.75);
-  t.equal(percentile([5, 4, 1, 3, 2], 75), 4.25);
-  t.equal(percentile([1, 2, 3, 4, 5], 44), 2.7);
-  t.equal(percentile([100, 101, 92, 4, 102, 66, 66], 17).toFixed(2), '46.78');
-  t.equal(percentile([100, 101, -92, 4, 102, 32], 50), 66);
+  t.equal(percentile([1, 2, 3, 4, 5], 0.15).toFixed(2), '1.60');
+  t.equal(percentile([5, 4, 1, 3, 2], 0.35).toFixed(2), '2.40');
+  t.equal(percentile([1, 2, 3, 4, 5], 0.44).toFixed(2), '2.76');
+  t.equal(percentile([100, 101, 92, 4, 102, 66, 66], 0.65).toFixed(2), '99.20');
+  t.equal(percentile([100, 101, 92, 4, 102, 32], 0.50).toFixed(2), '96.00');
   t.end();
+});
+
+test('array of known data set from spec', function(t) {
+  t.plan(1)
+  //from https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
+  var values = [
+    95.1772, 95.1567, 95.1937, 95.1959, 95.1442, 95.0610,
+    95.1591, 95.1195, 95.1065, 95.0925, 95.1990, 95.1682,
+  ];
+  var expectedPercentile = '95.1957';
+  t.equal(percentile(values, 0.90).toFixed(4), expectedPercentile);
+  t.end()
 });
 
 test('list of numeric arguments throws', function(t) {
   t.plan(2);
   t.throws(function() {
-    percentile(1, 2, 3, 4, 5, 50);
+    percentile(1, 2, 3, 4, 5, 0.50);
   });
   t.throws(function() {
-    percentile(1, 10);
+    percentile(1, 0.10);
   });
   t.end();
 });
@@ -43,19 +57,19 @@ test('list of numeric arguments throws', function(t) {
 test('non numeric values throw', function(t) {
   t.plan(5);
   t.throws(function() {
-    percentile([1, '2', 3, 4, 5], 50);
+    percentile([1, '2', 3, 4, 5], 0.50);
   });
   t.throws(function() {
-    percentile([], 20);
+    percentile([], 0.20);
   });
   t.throws(function() {
-    percentile([false, true], 66);
+    percentile([false, true], 0.66);
   });
   t.throws(function() {
-    percentile([{}], 66);
+    percentile([{}], 0.66);
   });
   t.throws(function() {
-    percentile(null, 40);
+    percentile(null, 0.40);
   });
   t.end();
 });


### PR DESCRIPTION
I was testing the percentile algorithm, and noticed it was giving different values than other tools like google sheets and python. 

After a ton of research I realized there are two main algorithms. Percentile exclusive, and percentile inclusive. The default alg for google sheets, excel, R, and python are all the inclusive version.

I changed it to the R7 algorithm specified in [the nist spec](https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm). This seems to be the most useful/commonly used version. It might be worth adding more under different exports in the future.

I also changed the percentage parameter to be decimal percentage instead. Chose to do this because percentage values are easier to work with between 0 and 1. If you want me to change this back I can, I just thought it was a good idea.