### PR TITLE
Add generic type goodness to 'just-capitalize'

### DIFF
--- a/packages/string-capitalize/index.d.ts
+++ b/packages/string-capitalize/index.d.ts
@@ -1,2 +1,2 @@
-declare function capitalize(value: string): string;
+declare function capitalize<T extends string>(value: T): Capitalize<T>;
 export default capitalize;


### PR DESCRIPTION
Currently when using `capitalize` in a Typescript project, the return type is just a string, but Typescript has [a Capitalize generic type](https://www.typescriptlang.org/docs/handbook/utility-types.html#capitalizestringtype) which can take in a string constant type and return the capitalized string constant type. This allows the return value of say `capitalize('hi')` to be exactly `'Hi'` rather than just `string`.

Here's a screenshot of how it looks when using the changed utility in a project:

![screenshot_of_exact_capitalization_typing](https://user-images.githubusercontent.com/9617471/138832839-46f28ace-bef6-4ac4-ac00-2dde63f3db47.png)

