### PR TITLE
Add generic typescript types for 'just-replace-all'

### DIFF
--- a/packages/string-replace-all/index.d.ts
+++ b/packages/string-replace-all/index.d.ts
@@ -1,0 +1,18 @@
+type ReplaceAll<
+  Str extends string,
+  SubStr extends string,
+  NewSubStr extends string
+> = Str extends `${infer Before}${SubStr}${infer After}`
+  ? `${Before}${NewSubStr}${ReplaceAll<After, SubStr, NewSubStr>}`
+  : Str;
+
+declare function replaceAll<
+  Str extends string,
+  SubStr extends string,
+  NewSubStr extends string
+>(
+  str: Str,
+  subStr: SubStr,
+  newSubStr: NewSubStr
+): ReplaceAll<Str, SubStr, NewSubStr>;
+export default replaceAll;

--- a/packages/string-replace-all/index.tests.ts
+++ b/packages/string-replace-all/index.tests.ts
@@ -1,0 +1,22 @@
+import replaceAll from "./index";
+
+// OK
+replaceAll("hello", "l", "w");
+
+// Not OK
+// @ts-expect-error
+replaceAll();
+// @ts-expect-error
+replaceAll(0);
+// @ts-expect-error
+replaceAll([]);
+// @ts-expect-error
+replaceAll({});
+// @ts-expect-error
+replaceAll(/nope/);
+// @ts-expect-error
+replaceAll(false);
+// @ts-expect-error
+replaceAll("hi");
+// @ts-expect-error
+replaceAll("hi", "h");

--- a/packages/string-replace-all/package.json
+++ b/packages/string-replace-all/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "replace all occurrences of a string within a string with another string",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Added types for `just-replace-all`. The generic type allows typescript to infer the correct return type for a given string.

See the below screenshot for an example in action:

![just-replace-all](https://user-images.githubusercontent.com/9617471/138840628-4b845a43-7a35-499c-bda0-012cca6e20e1.png)
