### PR TITLE
Add generic types to `just-map-values`

### DIFF
--- a/packages/object-map-values/index.d.ts
+++ b/packages/object-map-values/index.d.ts
@@ -1,3 +1,11 @@
-// Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
-declare function map<T extends {}>(item: T, callback: (value: any, key: string, object: T) => any): {};
-export default map;
+// Original definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
+declare function mapValues<TInput extends {}, TMappedValue>(
+  item: TInput,
+  callback: (
+    value: TInput[keyof TInput],
+    key: keyof TInput,
+    object: TInput
+  ) => TMappedValue
+): { [k in keyof TInput]: ReturnType<typeof callback> };
+
+export default mapValues;

--- a/packages/object-map-values/index.tests.ts
+++ b/packages/object-map-values/index.tests.ts
@@ -1,6 +1,6 @@
 import map from './index'
 
-const obj = {foo: {bar: []}};
+const obj = {foo: 1};
 
 // OK
 map(obj, (value) => value + 1);


### PR DESCRIPTION
The generic types allow Typescript to infer the correct return type.