### PR TITLE
Types: Add generic type for just-flip-object

### DIFF
--- a/packages/object-flip/index.d.ts
+++ b/packages/object-flip/index.d.ts
@@ -1,0 +1,9 @@
+type Primitive = boolean | string | number | bigint | null | undefined;
+
+type KeyType = string | number | symbol;
+
+declare function flip<T extends Record<KeyType, Primitive>>(
+  obj: T
+): { [U in keyof T as `${T[U]}`]: U };
+
+export default flip;

--- a/packages/object-flip/index.tests.ts
+++ b/packages/object-flip/index.tests.ts
@@ -1,0 +1,25 @@
+import flip from "./index";
+
+// OK
+flip({ a: 5 });
+flip({ a: "x", b: "y", c: "z" }); // {x: 'a', y: 'b', z: 'c'}
+flip({ a: 1, b: 2, c: 3 }); // {'1': 'a', '2': 'b', '3': 'c'}
+flip({ a: false, b: true }); // {false: 'a', true: 'b'}
+
+// Not OK
+// @ts-expect-error
+flip(5);
+// @ts-expect-error
+flip(true);
+// @ts-expect-error
+flip();
+// @ts-expect-error
+flip("{hi: 'bye'}");
+// @ts-expect-error
+flip(["a", "b", "c"]);
+// @ts-expect-error
+flip(new Set());
+// @ts-expect-error
+flip(new Map());
+// @ts-expect-error
+flip(() => {});

--- a/packages/object-flip/package.json
+++ b/packages/object-flip/package.json
@@ -11,6 +11,7 @@
       "default": "./index.esm.js"
     }
   },
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c"


### PR DESCRIPTION
Add generic type for just-flip-object.

Typescript will infer the correct shape of the flipped object whenever possible. See example:

![just-flip](https://user-images.githubusercontent.com/9617471/139572843-dffac12c-84b2-48bb-befc-aeb02d63be9f.png)

