### PR TITLE
Add more specific generic type overload to just-last

### DIFF
--- a/packages/array-last/index.d.ts
+++ b/packages/array-last/index.d.ts
@@ -6,4 +6,5 @@
  * last([])
  * // => undefined
  */
+export default function last<T>(arr: readonly [...any, T]): T;
 export default function last<T>(arr: T[]): T;

--- a/packages/array-last/index.tests.ts
+++ b/packages/array-last/index.tests.ts
@@ -3,11 +3,21 @@ import last from './index'
 // OK
 const test1: number = last([1, 2, 3, 4, 5]);
 const test2: number[] = last([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+const test3: { d: number } = last([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+const test4: RegExp = last(["a", 1, true, /r/g]);
 const test5: number = last([1]);
 const test6: undefined = last([]);
-//you have to be a bit more generic when array has mixed types
-const test3: object = last([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
-const test4: any = last(['a', 1, true, /r/g]);
+
+// make sure it works with readonly arrays
+const test7: 5 = last([1, 2, 3, 4, 5] as const);
+
+// make sure it works with dynamic arrays and not just static ones
+const dynArr = [1, 2, 3];
+dynArr.push(4);
+const test8: number = last(dynArr);
+const dynArr2: (number | string)[] = [1, 2];
+dynArr2.push("hi");
+const test9: number | string = last(dynArr2);
 
 // Not OK
 // @ts-expect-error


### PR DESCRIPTION
Add generic type overload to just-last.

Typescript can now determine the exact type of the last array for readonly arrays:

![just-array-last](https://user-images.githubusercontent.com/9617471/139573981-77a336b8-195b-406d-abfd-cd301b53ee48.png)

