### PR TITLE
Fix diff and diff-apply ESM error

### DIFF
--- a/packages/collection-diff-apply/index.esm.js
+++ b/packages/collection-diff-apply/index.esm.js
@@ -1,8 +1,3 @@
-var collectionDiffApply = {
-  diffApply: diffApply,
-  jsonPatchPathConverter: jsonPatchPathConverter,
-};
-
 /*
   const obj1 = {a: 3, b: 5};
   diffApply(obj1,
@@ -44,17 +39,17 @@ var collectionDiffApply = {
   obj4; // {a: 5, b: {d: 4}}
 */
 
-var REMOVE = 'remove';
-var REPLACE = 'replace';
-var ADD = 'add';
+var REMOVE = "remove";
+var REPLACE = "replace";
+var ADD = "add";
 
 function diffApply(obj, diff, pathConverter) {
-  if (!obj || typeof obj != 'object') {
-    throw new Error('base object must be an object or an array');
+  if (!obj || typeof obj != "object") {
+    throw new Error("base object must be an object or an array");
   }
 
   if (!Array.isArray(diff)) {
-    throw new Error('diff must be an array');
+    throw new Error("diff must be an array");
   }
 
   var diffLength = diff.length;
@@ -66,11 +61,13 @@ function diffApply(obj, diff, pathConverter) {
     if (pathConverter) {
       thisPath = pathConverter(thisPath);
       if (!Array.isArray(thisPath)) {
-        throw new Error('pathConverter must return an array');
+        throw new Error("pathConverter must return an array");
       }
     } else {
       if (!Array.isArray(thisPath)) {
-        throw new Error('diff path must be an array, consider supplying a path converter');
+        throw new Error(
+          "diff path must be an array, consider supplying a path converter"
+        );
       }
     }
     var pathCopy = thisPath.slice();
@@ -79,7 +76,7 @@ function diffApply(obj, diff, pathConverter) {
       return false;
     }
     var thisProp;
-    while (((thisProp = pathCopy.shift())) != null) {
+    while ((thisProp = pathCopy.shift()) != null) {
       if (!(thisProp in subObject)) {
         subObject[thisProp] = {};
       }
@@ -87,11 +84,17 @@ function diffApply(obj, diff, pathConverter) {
     }
     if (thisOp === REMOVE || thisOp === REPLACE) {
       if (!subObject.hasOwnProperty(lastProp)) {
-        throw new Error(['expected to find property', thisDiff.path, 'in object', obj].join(' '));
+        throw new Error(
+          ["expected to find property", thisDiff.path, "in object", obj].join(
+            " "
+          )
+        );
       }
     }
     if (thisOp === REMOVE) {
-      Array.isArray(subObject) ? subObject.splice(lastProp, 1) : delete subObject[lastProp];
+      Array.isArray(subObject)
+        ? subObject.splice(lastProp, 1)
+        : delete subObject[lastProp];
     }
     if (thisOp === REPLACE || thisOp === ADD) {
       subObject[lastProp] = thisDiff.value;
@@ -101,7 +104,7 @@ function diffApply(obj, diff, pathConverter) {
 }
 
 function jsonPatchPathConverter(stringPath) {
-  return stringPath.split('/').slice(1);
+  return stringPath.split("/").slice(1);
 }
 
-export { collectionDiffApply as default };
+export { diffApply, jsonPatchPathConverter };

--- a/packages/collection-diff/index.esm.js
+++ b/packages/collection-diff/index.esm.js
@@ -1,8 +1,3 @@
-var collectionDiff = {
-  diff: diff,
-  jsonPatchPathConverter: jsonPatchPathConverter,
-};
-
 /*
   const obj1 = {a: 4, b: 5};
   const obj2 = {a: 3, b: 5};
@@ -70,12 +65,12 @@ var collectionDiff = {
 */
 
 function diff(obj1, obj2, pathConverter) {
-  if (!obj1 || typeof obj1 != 'object' || !obj2 || typeof obj2 != 'object') {
-    throw new Error('both arguments must be objects or arrays');
+  if (!obj1 || typeof obj1 != "object" || !obj2 || typeof obj2 != "object") {
+    throw new Error("both arguments must be objects or arrays");
   }
 
   pathConverter ||
-    (pathConverter = function(arr) {
+    (pathConverter = function (arr) {
       return arr;
     });
 
@@ -91,7 +86,7 @@ function diff(obj1, obj2, pathConverter) {
       if (!(key in obj2)) {
         path = basePath.concat(key);
         diffs.remove.push({
-          op: 'remove',
+          op: "remove",
           path: pathConverter(path),
         });
       }
@@ -105,7 +100,7 @@ function diff(obj1, obj2, pathConverter) {
         path = basePath.concat(key);
         var obj2Value = obj2[key];
         diffs.add.push({
-          op: 'add',
+          op: "add",
           path: pathConverter(path),
           value: obj2Value,
         });
@@ -129,18 +124,15 @@ function diff(obj1, obj2, pathConverter) {
       }
     }
 
-    return diffs.remove
-      .reverse()
-      .concat(diffs.replace)
-      .concat(diffs.add);
+    return diffs.remove.reverse().concat(diffs.replace).concat(diffs.add);
   }
-  return getDiff(obj1, obj2, [], {remove: [], replace: [], add: []});
+  return getDiff(obj1, obj2, [], { remove: [], replace: [], add: [] });
 }
 
 function pushReplace(path, basePath, key, diffs, pathConverter, obj2) {
   path = basePath.concat(key);
   diffs.replace.push({
-    op: 'replace',
+    op: "replace",
     path: pathConverter(path),
     value: obj2[key],
   });
@@ -148,7 +140,7 @@ function pushReplace(path, basePath, key, diffs, pathConverter, obj2) {
 }
 
 function jsonPatchPathConverter(arrayPath) {
-  return [''].concat(arrayPath).join('/');
+  return [""].concat(arrayPath).join("/");
 }
 
-export { collectionDiff as default };
+export { diff, jsonPatchPathConverter };


### PR DESCRIPTION
When this library was converted to ESM, the packages with named exports weren't named exports anymore, rather an object `{ 
 diff, jsonThing }` was exported as `default`, which broke ESM builds.

This PR fixes that issue