### PR TITLE
Types: better generic type for just-union

### DIFF
--- a/packages/array-union/index.d.ts
+++ b/packages/array-union/index.d.ts
@@ -1,1 +1,8 @@
-export default function union<T, U>(arr1: T[], arr2: U[]): (T | U)[]
+export default function union<T extends any[], U extends any[]>(
+  arr1: T,
+  arr2: U
+): [...T, ...U];
+export default function union<
+  T extends readonly any[],
+  U extends readonly any[]
+>(arr1: T, arr2: U): [...T, ...U];


### PR DESCRIPTION
Adds better support for readonly arrays to the types for `just-union`.

See example:

![just-array-const](https://user-images.githubusercontent.com/9617471/139595496-46d21346-310e-4c27-bb81-d8ea3e71eaee.png)


