### PR TITLE
Types: Generic type for just-squash

### DIFF
--- a/packages/string-squash/index.d.ts
+++ b/packages/string-squash/index.d.ts
@@ -1,0 +1,55 @@
+type Space = " ";
+
+type Tab = "\t";
+
+type NewLine = "\n";
+
+type FormFeed = "\f";
+
+type VertTab = "\v";
+
+type Return = "\r";
+
+type Replace<
+  T extends string,
+  Match extends string,
+  Replacement extends string
+> = T extends `${infer Start}${Match}${infer End}`
+  ? `${Start}${Replacement}${End}`
+  : T;
+
+type SquashExtra<
+  T extends string,
+  U extends string = Replace<T, Space, "">,
+  V extends string = Replace<T, Tab, "">,
+  W extends string = Replace<T, NewLine, "">,
+  X extends string = Replace<T, FormFeed, "">,
+  Y extends string = Replace<T, VertTab, "">,
+  Z extends string = Replace<T, Return, "">
+> = U extends T
+  ? V extends T
+    ? W extends T
+      ? X extends T
+        ? Y extends T
+          ? Z extends T
+            ? T
+            : SquashExtra<Z>
+          : SquashExtra<Y>
+        : SquashExtra<X>
+      : SquashExtra<W>
+    : SquashExtra<V>
+  : SquashExtra<U>;
+
+type Squash<T extends string, U extends boolean = false> = U extends true
+  ? SquashExtra<T>
+  : Replace<T, " ", ""> extends T
+  ? T
+  : Squash<Replace<T, " ", "">>;
+
+declare function squash<T extends string>(str: T): Squash<T>;
+declare function squash<T extends string, U extends boolean>(
+  str: T,
+  squashEscapeSequences: U
+): Squash<T, U>;
+
+export default squash;

--- a/packages/string-squash/index.tests.ts
+++ b/packages/string-squash/index.tests.ts
@@ -1,0 +1,41 @@
+import squash from "./index";
+
+// OK
+const test1: "thecatsatonthemat" = squash("the cat sat on the mat");
+const test2: "thecatsatonthemat" = squash(" the cat sat on the mat ");
+const test3: "\tthecat\nsat\fon\vthe\rmat" = squash(
+  "\tthe cat\n sat \fon \vthe \rmat "
+);
+const test4: "thecatsatonthemat" = squash(
+  "\tthe cat\n sat \fon \vthe \rmat ",
+  true
+);
+const test5: "\tthecat\nsat\fon\vthe\rmat" = squash(
+  "\tthe cat\n sat \fon \vthe \rmat ",
+  false
+);
+const test6: "thecatsatonthemat" = squash(
+  `the cat
+sat on the mat`,
+  true
+);
+
+// Not OK
+// @ts-expect-error
+squash([]);
+// @ts-expect-error
+squash(124.43);
+// @ts-expect-error
+squash({});
+// @ts-expect-error
+squash(true);
+// @ts-expect-error
+squash(false);
+// @ts-expect-error
+squash("hi", []);
+// @ts-expect-error
+squash("hi", {});
+// @ts-expect-error
+squash("hi", 1);
+// @ts-expect-error
+squash("hi", "a");

--- a/packages/string-squash/package.json
+++ b/packages/string-squash/package.json
@@ -11,6 +11,7 @@
       "default": "./index.esm.js"
     }
   },
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c"


### PR DESCRIPTION
Adds generic type to `just-squash` which can convert the type of the string appropriately

See screenshot:

![just-squash](https://user-images.githubusercontent.com/9617471/139599588-eb3de6b1-699b-43ae-b9a8-f5fcde534aa0.png)

