### PR TITLE
add "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "just",
   "version": "1.22.4",
   "description": "A library of simple dependency-free utilities that do just do one thing",
+  "type": "module",
   "main": "index.js",
   "directories": {
     "test": "test"

--- a/packages/array-cartesian-product/package.json
+++ b/packages/array-cartesian-product/package.json
@@ -2,6 +2,7 @@
   "name": "just-cartesian-product",
   "version": "3.1.1",
   "description": "Cartesian product of arrays",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-compact/package.json
+++ b/packages/array-compact/package.json
@@ -2,6 +2,7 @@
   "name": "just-compact",
   "version": "2.4.1",
   "description": "returns a copy of an array with falsey values removed",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-flatten/package.json
+++ b/packages/array-flatten/package.json
@@ -2,6 +2,7 @@
   "name": "just-flatten-it",
   "version": "4.2.1",
   "description": "return a flattened array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-group-by/package.json
+++ b/packages/array-group-by/package.json
@@ -2,6 +2,7 @@
   "name": "just-group-by",
   "version": "1.3.1",
   "description": "return a grouped object from array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-index/package.json
+++ b/packages/array-index/package.json
@@ -2,6 +2,7 @@
   "name": "just-index",
   "version": "3.2.1",
   "description": "return an object from an array, keyed by the value at the given id",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-insert/package.json
+++ b/packages/array-insert/package.json
@@ -2,6 +2,7 @@
   "name": "just-insert",
   "version": "2.4.1",
   "description": "Inserts a sub-array into an array starting at the given index. Returns a copy",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-intersect/package.json
+++ b/packages/array-intersect/package.json
@@ -2,6 +2,7 @@
   "name": "just-intersect",
   "version": "3.4.1",
   "description": "return the intersect of two arrays",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-last/package.json
+++ b/packages/array-last/package.json
@@ -2,6 +2,7 @@
   "name": "just-last",
   "version": "2.4.1",
   "description": "return the last member of an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-mean/package.json
+++ b/packages/array-mean/package.json
@@ -2,6 +2,7 @@
   "name": "just-mean",
   "version": "1.3.1",
   "description": "the mean (average) value in an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-median/package.json
+++ b/packages/array-median/package.json
@@ -2,6 +2,7 @@
   "name": "just-median",
   "version": "1.2.1",
   "description": "return the median value of an array of numbers",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-mode/package.json
+++ b/packages/array-mode/package.json
@@ -2,6 +2,7 @@
   "name": "just-mode",
   "version": "1.2.1",
   "description": "return the most frequently occuring number(s)",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-partition/package.json
+++ b/packages/array-partition/package.json
@@ -2,6 +2,7 @@
   "name": "just-partition",
   "version": "1.4.1",
   "description": "Elements satisfying predicate added to first array, remainder added to second",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-percentile/package.json
+++ b/packages/array-percentile/package.json
@@ -2,6 +2,7 @@
   "name": "just-percentile",
   "version": "2.1.1",
   "description": "return the value at the given percentile (using linear interpolation)",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-permutations/package.json
+++ b/packages/array-permutations/package.json
@@ -2,6 +2,7 @@
   "name": "just-permutations",
   "version": "1.2.1",
   "description": "Returns all permutations of the length N of the elements of the given Array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-random/package.json
+++ b/packages/array-random/package.json
@@ -2,6 +2,7 @@
   "name": "just-random",
   "version": "2.2.1",
   "description": "return a randomly selected element in an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-range/package.json
+++ b/packages/array-range/package.json
@@ -2,6 +2,7 @@
   "name": "just-range",
   "version": "3.1.1",
   "description": "Generate a range array for numbers",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-remove/package.json
+++ b/packages/array-remove/package.json
@@ -2,6 +2,7 @@
   "name": "just-remove",
   "version": "2.2.1",
   "description": "removes one array from another",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-shuffle/package.json
+++ b/packages/array-shuffle/package.json
@@ -2,6 +2,7 @@
   "name": "just-shuffle",
   "version": "3.2.1",
   "description": "return the elements of an array in random order",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-skewness/package.json
+++ b/packages/array-skewness/package.json
@@ -2,6 +2,7 @@
   "name": "just-skewness",
   "version": "1.2.1",
   "description": "return the skewness of an array or numeric argument list using Pearson's second skewness coefficient",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-sort-by/package.json
+++ b/packages/array-sort-by/package.json
@@ -2,6 +2,7 @@
   "name": "just-sort-by",
   "version": "2.1.1",
   "description": "Produces a new array, sorted in ascending order",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-split-at/package.json
+++ b/packages/array-split-at/package.json
@@ -2,6 +2,7 @@
   "name": "just-split-at",
   "version": "2.3.1",
   "description": "splits an array into two at a given position",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-split/package.json
+++ b/packages/array-split/package.json
@@ -2,6 +2,7 @@
   "name": "just-split",
   "version": "2.3.1",
   "description": "Splits array into groups of n items each",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-standard-deviation/package.json
+++ b/packages/array-standard-deviation/package.json
@@ -2,6 +2,7 @@
   "name": "just-standard-deviation",
   "version": "1.2.1",
   "description": "return the standard deviation of an array or numeric argument list",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-tail/package.json
+++ b/packages/array-tail/package.json
@@ -2,6 +2,7 @@
   "name": "just-tail",
   "version": "2.3.1",
   "description": "return all but the first element of an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-union/package.json
+++ b/packages/array-union/package.json
@@ -2,6 +2,7 @@
   "name": "just-union",
   "version": "2.3.1",
   "description": "returns the union of two arrays",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-unique/package.json
+++ b/packages/array-unique/package.json
@@ -2,6 +2,7 @@
   "name": "just-unique",
   "version": "3.4.1",
   "description": "dedupes an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-variance/package.json
+++ b/packages/array-variance/package.json
@@ -2,6 +2,7 @@
   "name": "just-variance",
   "version": "1.2.1",
   "description": "return the standard deviation of an array or numeric argument list",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/array-zip/package.json
+++ b/packages/array-zip/package.json
@@ -2,6 +2,7 @@
   "name": "just-zip-it",
   "version": "2.3.1",
   "description": "returns an array of grouped elements, taking n-th element from every given array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-clone/package.json
+++ b/packages/collection-clone/package.json
@@ -2,6 +2,7 @@
   "name": "just-clone",
   "version": "4.1.1",
   "description": "deep copies objects and arrays",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-compare/package.json
+++ b/packages/collection-compare/package.json
@@ -2,6 +2,7 @@
   "name": "just-compare",
   "version": "1.5.1",
   "description": "compare two collections",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-diff-apply/package.json
+++ b/packages/collection-diff-apply/package.json
@@ -2,6 +2,7 @@
   "name": "just-diff-apply",
   "version": "3.1.2",
   "description": "Apply a diff to an object. Optionally supports jsonPatch protocol",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-diff/package.json
+++ b/packages/collection-diff/package.json
@@ -2,6 +2,7 @@
   "name": "just-diff",
   "version": "4.1.2",
   "description": "Return an object representing the diffs between two objects. Supports jsonPatch protocol",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-flush/package.json
+++ b/packages/collection-flush/package.json
@@ -2,6 +2,7 @@
   "name": "just-flush",
   "version": "1.2.1",
   "description": "returns a copy of an array or object with null/undefined members removed",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/collection-pluck/package.json
+++ b/packages/collection-pluck/package.json
@@ -2,6 +2,7 @@
   "name": "just-pluck-it",
   "version": "1.3.1",
   "description": "pluck a property from each member of a collection",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-compose/package.json
+++ b/packages/function-compose/package.json
@@ -2,6 +2,7 @@
   "name": "just-compose",
   "version": "1.2.1",
   "description": "return a function composed of 2 or more functions",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-curry/package.json
+++ b/packages/function-curry/package.json
@@ -2,6 +2,7 @@
   "name": "just-curry-it",
   "version": "4.1.1",
   "description": "return a curried function",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-debounce/package.json
+++ b/packages/function-debounce/package.json
@@ -2,6 +2,7 @@
   "name": "just-debounce-it",
   "version": "2.1.1",
   "description": "return a debounced function",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-demethodize/package.json
+++ b/packages/function-demethodize/package.json
@@ -2,6 +2,7 @@
   "name": "just-demethodize",
   "version": "2.2.1",
   "description": "turn a method into a standalone function; the first arg becomes `this`",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-flip/package.json
+++ b/packages/function-flip/package.json
@@ -2,6 +2,7 @@
   "name": "just-flip",
   "version": "1.2.1",
   "description": "flip first two arguments of a function",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-memoize-last/package.json
+++ b/packages/function-memoize-last/package.json
@@ -2,6 +2,7 @@
   "name": "just-memoize-last",
   "version": "2.1.1",
   "description": "A memoize implementation that only caches the most recent evaluation",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-memoize/package.json
+++ b/packages/function-memoize/package.json
@@ -2,6 +2,7 @@
   "name": "just-memoize",
   "version": "1.3.1",
   "description": "An implementation of the memoize technique",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-once/package.json
+++ b/packages/function-once/package.json
@@ -2,6 +2,7 @@
   "name": "just-once",
   "version": "1.4.1",
   "description": "create a function that can only be invoked once",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-partial/package.json
+++ b/packages/function-partial/package.json
@@ -2,6 +2,7 @@
   "name": "just-partial-it",
   "version": "2.2.1",
   "description": "return a partial function",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/function-throttle/package.json
+++ b/packages/function-throttle/package.json
@@ -2,6 +2,7 @@
   "name": "just-throttle",
   "version": "3.1.1",
   "description": "return a throttled function",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/number-clamp/package.json
+++ b/packages/number-clamp/package.json
@@ -2,6 +2,7 @@
   "name": "just-clamp",
   "version": "3.3.1",
   "description": "restrict a number within a range",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/number-is-prime/package.json
+++ b/packages/number-is-prime/package.json
@@ -2,6 +2,7 @@
   "name": "just-is-prime",
   "version": "1.2.1",
   "description": "Check if number is prime",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/number-modulo/package.json
+++ b/packages/number-modulo/package.json
@@ -2,6 +2,7 @@
   "name": "just-modulo",
   "version": "1.3.1",
   "description": "modulo of a number and a divisor",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/number-random-integer/package.json
+++ b/packages/number-random-integer/package.json
@@ -2,6 +2,7 @@
   "name": "just-random-integer",
   "version": "2.1.1",
   "description": "Produces an integer between two values",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-entries/package.json
+++ b/packages/object-entries/package.json
@@ -2,6 +2,7 @@
   "name": "just-entries",
   "version": "1.2.1",
   "description": "return object entries as an array of [key, value] pairs",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-extend/package.json
+++ b/packages/object-extend/package.json
@@ -2,6 +2,7 @@
   "name": "just-extend",
   "version": "5.1.1",
   "description": "extend an object",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-filter/package.json
+++ b/packages/object-filter/package.json
@@ -2,6 +2,7 @@
   "name": "just-filter-object",
   "version": "2.1.1",
   "description": "filter an object",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-flip/package.json
+++ b/packages/object-flip/package.json
@@ -2,6 +2,7 @@
   "name": "just-flip-object",
   "version": "1.2.1",
   "description": "flip the keys and values",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-has/package.json
+++ b/packages/object-has/package.json
@@ -2,6 +2,7 @@
   "name": "just-has",
   "version": "1.1.1",
   "description": "return a boolen indicating the existence of a deep property, don't throw if parent is undefined",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-is-circular/package.json
+++ b/packages/object-is-circular/package.json
@@ -2,6 +2,7 @@
   "name": "just-is-circular",
   "version": "1.2.1",
   "description": "determine if an object contains a circular reference",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-is-empty/package.json
+++ b/packages/object-is-empty/package.json
@@ -2,6 +2,7 @@
   "name": "just-is-empty",
   "version": "2.1.1",
   "description": "return true if object has no enumerable key values",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-is-primitive/package.json
+++ b/packages/object-is-primitive/package.json
@@ -2,6 +2,7 @@
   "name": "just-is-primitive",
   "version": "1.2.1",
   "description": "determine if a value is a primitive value",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-map-keys/package.json
+++ b/packages/object-map-keys/package.json
@@ -2,6 +2,7 @@
   "name": "just-map-keys",
   "version": "1.2.1",
   "description": "map an object, predicate updates keys, receives (value, key, object)",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-map-values/package.json
+++ b/packages/object-map-values/package.json
@@ -2,6 +2,7 @@
   "name": "just-map-values",
   "version": "2.2.1",
   "description": "map an object, predicate updates values, receives (value, key, object)",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-map/package.json
+++ b/packages/object-map/package.json
@@ -2,6 +2,7 @@
   "name": "just-map-object",
   "version": "1.3.1",
   "description": "map an object, passing key and value to predicates",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-merge/package.json
+++ b/packages/object-merge/package.json
@@ -2,6 +2,7 @@
   "name": "just-merge",
   "version": "2.1.1",
   "description": "shallow extend an object",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-omit/package.json
+++ b/packages/object-omit/package.json
@@ -2,6 +2,7 @@
   "name": "just-omit",
   "version": "1.4.1",
   "description": "copy an object but omit the specified keys",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-pick/package.json
+++ b/packages/object-pick/package.json
@@ -2,6 +2,7 @@
   "name": "just-pick",
   "version": "3.1.1",
   "description": "copy an object but with only the specified keys",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-reduce/package.json
+++ b/packages/object-reduce/package.json
@@ -2,6 +2,7 @@
   "name": "just-reduce-object",
   "version": "1.2.1",
   "description": "reduce an object",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-safe-get/package.json
+++ b/packages/object-safe-get/package.json
@@ -2,6 +2,7 @@
   "name": "just-safe-get",
   "version": "3.1.1",
   "description": "get value at property, don't throw if parent is undefined",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-safe-set/package.json
+++ b/packages/object-safe-set/package.json
@@ -2,6 +2,7 @@
   "name": "just-safe-set",
   "version": "3.1.1",
   "description": "set value at property, create intermediate properties if necessary",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-typeof/package.json
+++ b/packages/object-typeof/package.json
@@ -2,6 +2,7 @@
   "name": "just-typeof",
   "version": "2.1.1",
   "description": "type inferer",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/object-values/package.json
+++ b/packages/object-values/package.json
@@ -2,6 +2,7 @@
   "name": "just-values",
   "version": "1.4.1",
   "description": "return property values as an array",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-camel-case/package.json
+++ b/packages/string-camel-case/package.json
@@ -2,6 +2,7 @@
   "name": "just-camel-case",
   "version": "5.1.1",
   "description": "convert a string to camel case",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-capitalize/package.json
+++ b/packages/string-capitalize/package.json
@@ -2,6 +2,7 @@
   "name": "just-capitalize",
   "version": "2.2.1",
   "description": "capitalize the first character of a string",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-kebab-case/package.json
+++ b/packages/string-kebab-case/package.json
@@ -2,6 +2,7 @@
   "name": "just-kebab-case",
   "version": "3.1.1",
   "description": "convert a string to kebab case",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-pascal-case/package.json
+++ b/packages/string-pascal-case/package.json
@@ -2,6 +2,7 @@
   "name": "just-pascal-case",
   "version": "2.1.1",
   "description": "convert a string to pascal case",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-prune/package.json
+++ b/packages/string-prune/package.json
@@ -2,6 +2,7 @@
   "name": "just-prune",
   "version": "1.2.1",
   "description": "prune a string with whole words and a custom suffix",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-replace-all/package.json
+++ b/packages/string-replace-all/package.json
@@ -2,6 +2,7 @@
   "name": "just-replace-all",
   "version": "1.2.1",
   "description": "replace all occurrences of a string within a string with another string",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-right-pad/package.json
+++ b/packages/string-right-pad/package.json
@@ -2,6 +2,7 @@
   "name": "just-right-pad",
   "version": "2.2.1",
   "description": "add characters to the right of a string such that its total length is n",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-snake-case/package.json
+++ b/packages/string-snake-case/package.json
@@ -2,6 +2,7 @@
   "name": "just-snake-case",
   "version": "2.1.1",
   "description": "convert a string to snake case",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-squash/package.json
+++ b/packages/string-squash/package.json
@@ -2,6 +2,7 @@
   "name": "just-squash",
   "version": "1.2.1",
   "description": "remove all spaces from a string, optionally remove escape sequences too",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-template/package.json
+++ b/packages/string-template/package.json
@@ -2,6 +2,7 @@
   "name": "just-template",
   "version": "1.3.1",
   "description": "interpolate a string with variables",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {

--- a/packages/string-truncate/package.json
+++ b/packages/string-truncate/package.json
@@ -2,6 +2,7 @@
   "name": "just-truncate",
   "version": "1.3.1",
   "description": "truncate a string with a custom suffix",
+  "type": "module",
   "main": "index.js",
   "module": "index.esm.js",
   "exports": {


### PR DESCRIPTION
Very dirty approach to fix https://github.com/angus-c/just/issues/332 and https://github.com/angus-c/just/pull/334

Current version fails to build in project with "type": "module" in package.json.
Even if we add "module": "index.esm.js" it's ignored till I update package.json to module.
That solution certainly will fix svelte-kit, but can broke nextjs.