### PR TITLE
add `./package.json` to exports

### DIFF
--- a/packages/array-cartesian-product/package.json
+++ b/packages/array-cartesian-product/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-compact/package.json
+++ b/packages/array-compact/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-flatten/package.json
+++ b/packages/array-flatten/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-group-by/package.json
+++ b/packages/array-group-by/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-index/package.json
+++ b/packages/array-index/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-insert/package.json
+++ b/packages/array-insert/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-intersect/package.json
+++ b/packages/array-intersect/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-last/package.json
+++ b/packages/array-last/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-mean/package.json
+++ b/packages/array-mean/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-median/package.json
+++ b/packages/array-median/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-mode/package.json
+++ b/packages/array-mode/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/array-partition/package.json
+++ b/packages/array-partition/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-percentile/package.json
+++ b/packages/array-percentile/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/array-permutations/package.json
+++ b/packages/array-permutations/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-random/package.json
+++ b/packages/array-random/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-range/package.json
+++ b/packages/array-range/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-remove/package.json
+++ b/packages/array-remove/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-shuffle/package.json
+++ b/packages/array-shuffle/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-skewness/package.json
+++ b/packages/array-skewness/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/array-sort-by/package.json
+++ b/packages/array-sort-by/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-split-at/package.json
+++ b/packages/array-split-at/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-split/package.json
+++ b/packages/array-split/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-standard-deviation/package.json
+++ b/packages/array-standard-deviation/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/array-tail/package.json
+++ b/packages/array-tail/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-union/package.json
+++ b/packages/array-union/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-unique/package.json
+++ b/packages/array-unique/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/array-variance/package.json
+++ b/packages/array-variance/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/array-zip/package.json
+++ b/packages/array-zip/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/collection-clone/package.json
+++ b/packages/collection-clone/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/collection-compare/package.json
+++ b/packages/collection-compare/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/collection-diff-apply/package.json
+++ b/packages/collection-diff-apply/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/collection-diff/package.json
+++ b/packages/collection-diff/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/collection-flush/package.json
+++ b/packages/collection-flush/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/collection-pluck/package.json
+++ b/packages/collection-pluck/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/function-compose/package.json
+++ b/packages/function-compose/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/function-curry/package.json
+++ b/packages/function-curry/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/function-debounce/package.json
+++ b/packages/function-debounce/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/function-demethodize/package.json
+++ b/packages/function-demethodize/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/function-flip/package.json
+++ b/packages/function-flip/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/function-memoize-last/package.json
+++ b/packages/function-memoize-last/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/function-memoize/package.json
+++ b/packages/function-memoize/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/function-once/package.json
+++ b/packages/function-once/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/function-partial/package.json
+++ b/packages/function-partial/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/function-throttle/package.json
+++ b/packages/function-throttle/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/number-clamp/package.json
+++ b/packages/number-clamp/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/number-is-prime/package.json
+++ b/packages/number-is-prime/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/number-modulo/package.json
+++ b/packages/number-modulo/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/number-random-integer/package.json
+++ b/packages/number-random-integer/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-entries/package.json
+++ b/packages/object-entries/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-extend/package.json
+++ b/packages/object-extend/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-filter/package.json
+++ b/packages/object-filter/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-flip/package.json
+++ b/packages/object-flip/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-has/package.json
+++ b/packages/object-has/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-is-circular/package.json
+++ b/packages/object-is-circular/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-is-empty/package.json
+++ b/packages/object-is-empty/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-is-primitive/package.json
+++ b/packages/object-is-primitive/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-map-keys/package.json
+++ b/packages/object-map-keys/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-map-values/package.json
+++ b/packages/object-map-values/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-map/package.json
+++ b/packages/object-map/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-merge/package.json
+++ b/packages/object-merge/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-omit/package.json
+++ b/packages/object-omit/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-pick/package.json
+++ b/packages/object-pick/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-reduce/package.json
+++ b/packages/object-reduce/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/object-safe-get/package.json
+++ b/packages/object-safe-get/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-safe-set/package.json
+++ b/packages/object-safe-set/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-typeof/package.json
+++ b/packages/object-typeof/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/object-values/package.json
+++ b/packages/object-values/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-camel-case/package.json
+++ b/packages/string-camel-case/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-capitalize/package.json
+++ b/packages/string-capitalize/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-kebab-case/package.json
+++ b/packages/string-kebab-case/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-left-pad/package.json
+++ b/packages/string-left-pad/package.json
@@ -9,7 +9,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-pascal-case/package.json
+++ b/packages/string-pascal-case/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-prune/package.json
+++ b/packages/string-prune/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/string-replace-all/package.json
+++ b/packages/string-replace-all/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-right-pad/package.json
+++ b/packages/string-right-pad/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/string-snake-case/package.json
+++ b/packages/string-snake-case/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "scripts": {

--- a/packages/string-squash/package.json
+++ b/packages/string-squash/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/string-template/package.json
+++ b/packages/string-template/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/string-truncate/package.json
+++ b/packages/string-truncate/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./index.js",
       "default": "./index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Not exporting `./package.json` has been reported to be an issue in a couple other packages when used with some frontend related libraries and related bundlers.

There are more but to name a couple:
https://github.com/react-native-community/cli/issues/1168
https://github.com/sveltejs/rollup-plugin-svelte/issues/104