### PR TITLE
Fixed array-random types

### DIFF
--- a/packages/array-random/index.d.ts
+++ b/packages/array-random/index.d.ts
@@ -1,2 +1,3 @@
-export default function random<Head, Rest>(arr: [Head, ...Rest[]]): Head | Rest;
-export default function random<T>(arr: T[]): undefined; // return undefined for empty arrays.
+declare function random<Head, Rest>(arr: [Head, ...Rest[]]): Head | Rest;
+declare function random<T>(arr: T[]): T | undefined;
+export default random;

--- a/packages/array-random/index.tests.ts
+++ b/packages/array-random/index.tests.ts
@@ -1,13 +1,12 @@
-import random from './index';
+import random from "./index";
 
 // OK
-const test1: undefined = random([])
-const test2: 1 = random([1])
-const test3: number = random([1, 2, 3])
-const test4: (number | string) = random([1, 2, "a"])
-
-const numbers: number[] = []
-const test5: undefined = random(numbers)
+const test1: undefined = random([]);
+const test2: 1 = random([1]);
+const test3: number = random([1, 2, 3]);
+const test4: number | string = random([1, 2, "a"]);
+const numbers: number[] = [];
+const test6: number | undefined = random(numbers);
 
 // Not OK
 // @ts-expect-error
@@ -22,3 +21,7 @@ random(1);
 random([], []);
 // @ts-expect-error
 random("arr");
+
+const array = [1];
+// @ts-expect-error
+const result: undefined = random(array);


### PR DESCRIPTION
There was an error with the return type of the just-random function


When the ts compiler didn't know if the array was empty or not it would set the return type as undefined
example:
```
const array: number[] = [1, 2, 3];
// This caused a TS error
const result1: number = random(array);
// This didn't cause a TS error
const result2: undefined = random(array);
```

I've modified the types so that in this case TS will return the type or undefined
example:
```
const array: number[] = [1, 2, 3];
// This doesn't cause a TS error
const result: number | undefined = random(array);
```

I fixed this error and added new test cases to cover