### PR TITLE
Added object-deep-map-values

### DIFF
--- a/packages/object-deep-map-values/LICENSE
+++ b/packages/object-deep-map-values/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Max Ryan Synnott
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/object-deep-map-values/README.md
+++ b/packages/object-deep-map-values/README.md
@@ -1,0 +1,23 @@
+## just-deep-map-values
+
+Part of a [library](https://anguscroll.com/just) of zero-dependency npm modules that do just do one thing.
+Guilt-free utilities for every occasion.
+
+[`🍦 Try it`](https://anguscroll.com/just/just-deep-map-values)
+
+```shell
+npm install just-deep-map-values
+```
+
+```shell
+yarn add just-deep-map-values
+```
+
+Returns an object with values at all depths mapped according to the provided function
+
+```js
+import deepMapValues from "just-deep-map-values";
+
+const squareFn = (number) => number * number;
+deepMapValues({ a: 1, b: { c: 2, d: { e: 3 } } }, squareFn); // => { a: 1, b: { c: 4, d: { e: 9 } } }
+```

--- a/packages/object-deep-map-values/index.d.ts
+++ b/packages/object-deep-map-values/index.d.ts
@@ -1,0 +1,8 @@
+type RecursiveObject<T> = { [key: string]: T | RecursiveObject<T> };
+type MapFunction<T, U> = (value: T, key: string) => U;
+
+declare function deepMapValues<T, U = T>(
+  obj: RecursiveObject<T>,
+  fn: MapFunction<T, U>
+): RecursiveObject<U>;
+export default deepMapValues;

--- a/packages/object-deep-map-values/index.js
+++ b/packages/object-deep-map-values/index.js
@@ -1,12 +1,24 @@
 module.exports = deepMapValues;
 
 function deepMapValues(obj, fn) {
-  return Object.keys(obj).reduce(function(acc, key) {
+  if (!isObject(obj)) {
+    throw new Error('First argument must be an object');
+  }
+  if (!(fn instanceof Function)) {
+    throw new Error('Second argument must be a function');
+  }
+
+  var result = {};
+  var keys = Object.keys(obj);
+  var len = keys.length;
+  for (let i = 0; i < len; i++) {
+    var key = keys[i];
     var value = obj[key];
-    acc[key] =
-      Object.prototype.toString.call(value) === '[object Object]'
-        ? deepMapValues(value, fn)
-        : fn(value, key);
-    return acc;
-  }, {});
+    result[key] = isObject(value) ? deepMapValues(value, fn) : fn(value, key);
+  }
+  return result;
+}
+
+function isObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
 }

--- a/packages/object-deep-map-values/index.js
+++ b/packages/object-deep-map-values/index.js
@@ -1,7 +1,7 @@
 module.exports = deepMapValues;
 
 function deepMapValues(obj, fn) {
-  return Object.keys(obj).reduce(function (acc, key) {
+  return Object.keys(obj).reduce(function(acc, key) {
     var value = obj[key];
     acc[key] =
       Object.prototype.toString.call(value) === '[object Object]'

--- a/packages/object-deep-map-values/index.js
+++ b/packages/object-deep-map-values/index.js
@@ -1,0 +1,12 @@
+function deepMapValues(obj, fn) {
+  return Object.keys(obj).reduce(function (acc, key) {
+    var value = obj[key];
+    acc[key] =
+      Object.prototype.toString.call(value) === '[object Object]'
+        ? deepMapValues(value, fn)
+        : fn(value, key);
+    return acc;
+  }, {});
+}
+
+module.exports = deepMapValues;

--- a/packages/object-deep-map-values/index.mjs
+++ b/packages/object-deep-map-values/index.mjs
@@ -1,6 +1,4 @@
-module.exports = deepMapValues;
-
-function deepMapValues(obj, fn) {
+var deepMapValues = function deepMapValues(obj, fn) {
   return Object.keys(obj).reduce(function (acc, key) {
     var value = obj[key];
     acc[key] =
@@ -10,3 +8,5 @@ function deepMapValues(obj, fn) {
     return acc;
   }, {});
 }
+
+export {deepMapValues as default};

--- a/packages/object-deep-map-values/index.mjs
+++ b/packages/object-deep-map-values/index.mjs
@@ -1,12 +1,26 @@
-var deepMapValues = function deepMapValues(obj, fn) {
-  return Object.keys(obj).reduce(function (acc, key) {
+var objectDeepMapValues = deepMapValues;
+
+function deepMapValues(obj, fn) {
+  if (!isObject(obj)) {
+    throw new Error('First argument must be an object');
+  }
+  if (!(fn instanceof Function)) {
+    throw new Error('Second argument must be a function');
+  }
+
+  var result = {};
+  var keys = Object.keys(obj);
+  var len = keys.length;
+  for (let i = 0; i < len; i++) {
+    var key = keys[i];
     var value = obj[key];
-    acc[key] =
-      Object.prototype.toString.call(value) === '[object Object]'
-        ? deepMapValues(value, fn)
-        : fn(value, key);
-    return acc;
-  }, {});
+    result[key] = isObject(value) ? deepMapValues(value, fn) : fn(value, key);
+  }
+  return result;
 }
 
-export {deepMapValues as default};
+function isObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+export { objectDeepMapValues as default };

--- a/packages/object-deep-map-values/index.tests.ts
+++ b/packages/object-deep-map-values/index.tests.ts
@@ -1,0 +1,22 @@
+import deepMapValues from "./index";
+type RecursiveObject<T> = { [key: string]: T | RecursiveObject<T> };
+
+const test1: RecursiveObject<string[]> = deepMapValues(
+  { a: "string", b: { c: "apple" } },
+  (value) => value.split("")
+);
+const test2: RecursiveObject<boolean> = deepMapValues(
+  { a: 1, b: { c: 2 } },
+  (value) => value % 2 === 0
+);
+const test3: RecursiveObject<string> = deepMapValues(
+  { a: "pple", b: { c: "herry" } },
+  (value, key) => key + value
+);
+
+// @ts-expect-error
+deepMapValues();
+// @ts-expect-error
+deepMapValues({});
+// @ts-expect-error
+deepMapValues({ a: 1 }, (value: string) => {});

--- a/packages/object-deep-map-values/package.json
+++ b/packages/object-deep-map-values/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "just-deep-map-values",
+  "version": "1.0.0",
+  "description": "Returns an object with values at all depths mapped according to the provided function",
+  "main": "index.js",
+  "module": "index.mjs",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.mjs"
+    }
+  },
+  "types": "index.d.ts",
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "repository": "https://github.com/angus-c/just",
+  "keywords": [
+    "object",
+    "deep",
+    "map",
+    "values",
+    "no-dependencies",
+    "just"
+  ],
+  "author": {
+    "name": "Max Ryan Synnott",
+    "url": "https://github.com/maxsynnott/"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angus-c/just/issues"
+  }
+}

--- a/packages/object-deep-map-values/rollup.config.js
+++ b/packages/object-deep-map-values/rollup.config.js
@@ -1,0 +1,3 @@
+const createRollupConfig = require('../../config/createRollupConfig');
+
+module.exports = createRollupConfig(__dirname);

--- a/test/object-deep-map-values/index.js
+++ b/test/object-deep-map-values/index.js
@@ -1,0 +1,27 @@
+const test = require('../util/test')(__filename);
+const deepMapValues = require('../../packages/object-deep-map-values');
+
+const squareFn = (value) => value * value;
+const concatFn = (value, key) => key + value;
+
+test('correctly maps using value argument', (t) => {
+  t.plan(2);
+  const input1 = {a: 1, b: 2, c: 3};
+  const return1 = deepMapValues(input1, squareFn);
+  t.deepEqual(return1, {a: 1, b: 4, c: 9});
+  const input2 = {a: 1, b: {c: 2, d: {e: 3}}};
+  const return2 = deepMapValues(input2, squareFn);
+  t.deepEqual(return2, {a: 1, b: {c: 4, d: {e: 9}}});
+  t.end();
+});
+
+test('correctly maps using value and key arguments', (t) => {
+  t.plan(2);
+  const input1 = {a: 'pple', b: 'anana', c: 'herry'};
+  const return1 = deepMapValues(input1, concatFn);
+  t.deepEqual(return1, {a: 'apple', b: 'banana', c: 'cherry'});
+  const input2 = {a: 'pple', b: {c: 'herry', d: {e: 'lderberry'}}};
+  const return2 = deepMapValues(input2, concatFn);
+  t.deepEqual(return2, {a: 'apple', b: {c: 'cherry', d: {e: 'elderberry'}}});
+  t.end();
+});

--- a/test/object-deep-map-values/index.js
+++ b/test/object-deep-map-values/index.js
@@ -6,22 +6,46 @@ const concatFn = (value, key) => key + value;
 
 test('correctly maps using value argument', (t) => {
   t.plan(2);
-  const input1 = {a: 1, b: 2, c: 3};
-  const return1 = deepMapValues(input1, squareFn);
+  const object1 = {a: 1, b: 2, c: 3};
+  const return1 = deepMapValues(object1, squareFn);
   t.deepEqual(return1, {a: 1, b: 4, c: 9});
-  const input2 = {a: 1, b: {c: 2, d: {e: 3}}};
-  const return2 = deepMapValues(input2, squareFn);
+  const object2 = {a: 1, b: {c: 2, d: {e: 3}}};
+  const return2 = deepMapValues(object2, squareFn);
   t.deepEqual(return2, {a: 1, b: {c: 4, d: {e: 9}}});
   t.end();
 });
 
 test('correctly maps using value and key arguments', (t) => {
   t.plan(2);
-  const input1 = {a: 'pple', b: 'anana', c: 'herry'};
-  const return1 = deepMapValues(input1, concatFn);
+  const object1 = {a: 'pple', b: 'anana', c: 'herry'};
+  const return1 = deepMapValues(object1, concatFn);
   t.deepEqual(return1, {a: 'apple', b: 'banana', c: 'cherry'});
-  const input2 = {a: 'pple', b: {c: 'herry', d: {e: 'lderberry'}}};
-  const return2 = deepMapValues(input2, concatFn);
-  t.deepEqual(return2, {a: 'apple', b: {c: 'cherry', d: {e: 'elderberry'}}});
+  const object2 = {a: 'pple', b: {c: 'herry', d: {e: 'lderberry'}}};
+  const return2 = deepMapValues(object2, concatFn);
+  t.deepEqual(return2, {
+    a: 'apple',
+    b: {c: 'cherry', d: {e: 'elderberry'}},
+  });
+  t.end();
+});
+
+test('throws error when provided with invalid arguments', (t) => {
+  t.plan(4);
+  t.throws(
+    () => deepMapValues(),
+    new RegExp('First argument must be an object')
+  );
+  t.throws(
+    () => deepMapValues({}),
+    new RegExp('Second argument must be a function')
+  );
+  t.throws(
+    () => deepMapValues([1, 2, 3], squareFn),
+    new RegExp('First argument must be an object')
+  );
+  t.throws(
+    () => deepMapValues({a: 1, b: 2, c: 3}, {}),
+    new RegExp('Second argument must be a function')
+  );
   t.end();
 });


### PR DESCRIPTION
Added function to deeply map an objects values

example:
```js
import deepMapValues from "just-deep-map-values";
const squareFn = (number) => number * number;
deepMapValues({ a: 1, b: { c: 2, d: { e: 3 } } }, squareFn); // => { a: 1, b: { c: 4, d: { e: 9 } } }
```