### PR TITLE
Add readonly array capability to array-intersect

### DIFF
--- a/packages/array-intersect/index.d.ts
+++ b/packages/array-intersect/index.d.ts
@@ -6,4 +6,5 @@
  * intersect([1, 2, 2, 4, 5], [3, 2, 2, 5, 7]);
  * // => [2, 5]
  */
-export default function intersect<T, U, I extends T | U>(arr1: T[], arr2: U[]): I[]
+export default function intersect<T, U, I extends T | U>(arr1: T[], arr2: U[]): I[];
+export default function intersect<T, U, I extends T | U>(arr1: readonly T[], arr2: readonly U[]): I[];

--- a/packages/array-intersect/index.tests.ts
+++ b/packages/array-intersect/index.tests.ts
@@ -6,6 +6,8 @@ const test2: number[] = intersect([1, 2, 3], [2, 3, 4])
 const test3: (number | string)[] = intersect([1, 2, "a"], [2, 3, "a"])
 const test4: number[] = intersect([1, 2, "a"], [1, 2, true])
 const test5: unknown[] = intersect([1, 2, 3], ["a", "b", "c"])
+// check readonly types
+const test6: (1 | 2)[] = intersect([1, 2, 3] as const, [4, 5, 1, 2] as const)
 
 // Not OK
 // @ts-expect-error


### PR DESCRIPTION
This adds the ability to use readonly arrays with `intersect`, previously they threw a type error.