### PR TITLE
Add readonly array handling for array-tail

### DIFF
--- a/packages/array-tail/index.d.ts
+++ b/packages/array-tail/index.d.ts
@@ -1,4 +1,4 @@
-export default function tail<Tail>(arr: [unknown, ...Tail[]]): Tail[]
-export default function tail<T>(arr: T[]): T[]
-
-export default function tail<T>(arr: [unknown, ...T[]] | T[]): T[]
+export default function tail<Tail>(arr: [unknown, ...Tail[]]): Tail[];
+export default function tail<T>(arr: T[]): T[];
+export default function tail<T extends any[]>(arr: readonly [any, ...T]): T;
+export default function tail<T>(arr: [unknown, ...T[]] | T[]): T[];

--- a/packages/array-tail/index.tests.ts
+++ b/packages/array-tail/index.tests.ts
@@ -6,6 +6,7 @@ const test2: string[] = tail([1, 'a', 'b']);
 const test3: (number | string)[] = tail([1, 2, 'a', 'b']);
 const test4: boolean[] = tail([true]); // []
 const test5: number[] = tail([] as number[]); // []
+const test6: [2, 3] = tail([1, 2, 3] as const);
 
 // Not OK
 // @ts-expect-error
@@ -14,3 +15,5 @@ tail(); // throws
 tail({}); // throws
 // @ts-expect-error
 tail('array'); // throws
+// @ts-expect-error
+const test7: [1, 2] = tail([1, 2, 3] as const);


### PR DESCRIPTION
Adds handling for readonly arrays in `tail`.

Now you can do something like the following

```typescript
const arr = [1,2,3,4] as const;
const t: [2,3,4] = tail(arr);
```