### PR TITLE
Fixed test script to exit on lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "build": "lerna run build --stream $@",
-    "lint": "eslint .",
-    "test": "npm run lint && tape ./test/**/index.js | tap-spec; npm run test-types",
+    "lint": "eslint --max-warnings=0 .",
+    "test": "npm run lint && tape ./test/**/index.js | tap-spec && npm run test-types",
     "test-types": "tsc",
     "generate-readmes": "node scripts/generate-readmes.js"
   },


### PR DESCRIPTION
Previously the test script and therefore the build step would pass even if there were lint errors. This change causes the script to exit when there are lint errors and therefore fail the build