### PR TITLE
Remove excess triple-backticks before just-debounce-it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2309,7 +2309,7 @@ cubedRoot(64); // 4
 const getRoot = partial(Math.pow, 64);
 getRoot(1/2); // 8
 ```  
-```
+
 
 ### [just-debounce-it](https://www.npmjs.com/package/just-debounce-it)
 [source](https://github.com/angus-c/just/tree/master/packages/function-debounce/index.js)

--- a/README.md
+++ b/README.md
@@ -2308,8 +2308,7 @@ cubedRoot(64); // 4
 
 const getRoot = partial(Math.pow, 64);
 getRoot(1/2); // 8
-```  
-
+```
 
 ### [just-debounce-it](https://www.npmjs.com/package/just-debounce-it)
 [source](https://github.com/angus-c/just/tree/master/packages/function-debounce/index.js)

--- a/md-variables.json
+++ b/md-variables.json
@@ -814,8 +814,7 @@
       "cubedRoot(64); // 4",
       "",
       "const getRoot = partial(Math.pow, 64);",
-      "getRoot(1/2); // 8",
-      "```  "
+      "getRoot(1/2); // 8"
     ]
   },
   "just-throttle": {

--- a/packages/function-partial/README.md
+++ b/packages/function-partial/README.md
@@ -22,5 +22,4 @@ cubedRoot(64); // 4
 
 const getRoot = partial(Math.pow, 64);
 getRoot(1/2); // 8
-```  
 ```


### PR DESCRIPTION
the just-debounce-it section in the README was malformatted. therefore the anchor-link in the TOC did not work either.

thanks!