### PR TITLE
Fix README error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,7 +1206,6 @@ last(); // undefined
 last([]); // undefined
 last(null); // undefined
 last(undefined); // undefined
-```  
 ```
 
 ### [just-tail](https://www.npmjs.com/package/just-tail)

--- a/md-variables.json
+++ b/md-variables.json
@@ -102,8 +102,7 @@
       "last(); // undefined",
       "last([]); // undefined",
       "last(null); // undefined",
-      "last(undefined); // undefined",
-      "```  "
+      "last(undefined); // undefined"
     ]
   },
   "just-mean": {

--- a/packages/array-last/README.md
+++ b/packages/array-last/README.md
@@ -26,5 +26,4 @@ last(); // undefined
 last([]); // undefined
 last(null); // undefined
 last(undefined); // undefined
-```  
 ```


### PR DESCRIPTION
Removed extra backticks in array-last examples which was causing improper formatting in README