### PR TITLE
Add compatibility with TypeScript and ESM

### DIFF
--- a/packages/object-omit/index.d.mts
+++ b/packages/object-omit/index.d.mts
@@ -1,0 +1,2 @@
+export default function omit<Obj extends object, Key extends string>(obj: Obj, remove: Key[]): Omit<Obj, Key>;
+export default function omit<Obj extends object, Key extends string>(obj: Obj, remove1: Key, ...removeN: Key[]): Omit<Obj, Key>;

--- a/packages/object-omit/package.json
+++ b/packages/object-omit/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs"
+      "default": "./index.mjs",
+      "types": "./index.d.mts"
     }
   },
   "types": "index.d.ts",


### PR DESCRIPTION
This adds compatibility with TypeScript's [Experimental Support for ECMAScript Modules in Node.js](https://www.typescriptlang.org/docs/handbook/esm-node.html). I've seen the `package.json` syntax mentioned in https://github.com/microsoft/TypeScript/issues/33079 and it solves the issue for me.

It's meant as an example only, you might want to hold off merging this until TypeScript 4.7 is released. I'm not sure this will continue to work in the release. And if it does, you might want to do something similar for all the other packages in this repository. I've marked it as draft for these reasons.

Also, I haven't checked whether the syntax in `index.d.mts` would work with other TypeScript versions and configurations. If it does then it would be better to use a single file instead of both `index.d.ts` and `index.d.mts`.

And finally, I haven't checked whether TypeScript 4.7 _without_ ESM support enabled also needs the different syntax. If so, it might be necessary to use the [`typesVersion`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions) setting.

Fixes #428