### PR TITLE
Fix error for just-template when unresolved nested variables

### DIFF
--- a/packages/string-template/index.js
+++ b/packages/string-template/index.js
@@ -11,7 +11,10 @@ module.exports = template;
     },
     b: 'plum'
   };
-  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.', data);
+  template(
+    '2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.',
+    data
+  );
   // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear. No 0 .'
 */
 

--- a/packages/string-template/index.js
+++ b/packages/string-template/index.js
@@ -11,8 +11,8 @@ module.exports = template;
     },
     b: 'plum'
   };
-  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}.', data);
-  // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear.'
+  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.', data);
+  // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear. No 0 .'
 */
 
 function template(string, data) {

--- a/packages/string-template/index.js
+++ b/packages/string-template/index.js
@@ -21,6 +21,7 @@ function template(string, data) {
     var keyParts = key.split('.');
     var value = data;
     for (var i = 0; i < keyParts.length; i++) {
+      if (!value) return '';
       value = value[keyParts[i]];
     }
     return value || '';

--- a/packages/string-template/index.mjs
+++ b/packages/string-template/index.mjs
@@ -21,6 +21,7 @@ function template(string, data) {
     var keyParts = key.split('.');
     var value = data;
     for (var i = 0; i < keyParts.length; i++) {
+      if (!value) return '';
       value = value[keyParts[i]];
     }
     return value || '';

--- a/packages/string-template/index.mjs
+++ b/packages/string-template/index.mjs
@@ -11,7 +11,10 @@ var stringTemplate = template;
     },
     b: 'plum'
   };
-  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.', data);
+  template(
+    '2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.',
+    data
+  );
   // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear. No 0 .'
 */
 

--- a/packages/string-template/index.mjs
+++ b/packages/string-template/index.mjs
@@ -11,8 +11,8 @@ var stringTemplate = template;
     },
     b: 'plum'
   };
-  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}.', data);
-  // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear.'
+  template('2 {{a.aa.aaa}}s, a {{a.aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.aa.bbb}}. No 0 {{a.cc}}.', data);
+  // '2 apples, a pear, 3 oranges and a plum. Yes 1 pear. No 0 .'
 */
 
 function template(string, data) {

--- a/test/string-template/index.js
+++ b/test/string-template/index.js
@@ -52,3 +52,22 @@ test('unresolved variables return empty strings', function(t) {
   t.equal(template(str, data), 'a 3, b , c 4');
   t.end();
 });
+
+test('unresolved nested variables return empty strings', function(t) {
+  t.plan(1);
+  var str =
+    '2 {{a.aa.aaa}}s, a {{aa.bbb}}, 3 {{a.bb}}s and a {{b}}. Yes 1 {{a.bbb.a}}.';
+  var data = {
+    a: {
+      aa: {
+        aaa: 'apple',
+        bbb: 'pear',
+      },
+      bb: 'orange',
+    },
+    b: 'plum',
+  };
+  var result = '2 apples, a , 3 oranges and a plum. Yes 1 .';
+  t.equal(template(str, data), result);
+  t.end();
+});


### PR DESCRIPTION
This fixes an issue where `just-template` would throw the following error if a nested variable was found without a corresponding value.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'bbb')
```