### PR TITLE
update just-array-sort-by readme to reflect correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,7 +1360,7 @@ yarn add just-sort-by
 Produces a new array, sorted in ascending order
 
 ```js
-import sortBy from 'just-array-sort-by';
+import sortBy from 'just-sort-by';
 
 sortBy([10, 1, 5, 20, 15, 35, 30, 6, 8]); // [1, 5, 6, 8, 10, 15, 20, 30, 35]
 

--- a/md-variables.json
+++ b/md-variables.json
@@ -276,7 +276,7 @@
     "dir": "array-sort-by",
     "description": "Produces a new array, sorted in ascending order",
     "examples": [
-      "import sortBy from 'just-array-sort-by';",
+      "import sortBy from 'just-sort-by';",
       "",
       "sortBy([10, 1, 5, 20, 15, 35, 30, 6, 8]); // [1, 5, 6, 8, 10, 15, 20, 30, 35]",
       "",

--- a/packages/array-sort-by/README.md
+++ b/packages/array-sort-by/README.md
@@ -18,7 +18,7 @@ yarn add just-sort-by
 Produces a new array, sorted in ascending order
 
 ```js
-import sortBy from 'just-array-sort-by';
+import sortBy from 'just-sort-by';
 
 sortBy([10, 1, 5, 20, 15, 35, 30, 6, 8]); // [1, 5, 6, 8, 10, 15, 20, 30, 35]
 


### PR DESCRIPTION
This updates the `just-array-sort-by` README to show the correct importing syntax.