### PR TITLE
Add `undefined` to return type of array-last

### DIFF
--- a/packages/array-last/index.d.ts
+++ b/packages/array-last/index.d.ts
@@ -7,4 +7,4 @@
  * // => undefined
  */
 export default function last<T>(arr: readonly [...any, T]): T;
-export default function last<T>(arr: T[]): T;
+export default function last<T>(arr: T[]): T | undefined;

--- a/packages/array-last/index.tests.ts
+++ b/packages/array-last/index.tests.ts
@@ -1,11 +1,11 @@
 import last from './index'
 
 // OK
-const test1: number = last([1, 2, 3, 4, 5]);
-const test2: number[] = last([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
-const test3: { d: number } = last([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
-const test4: RegExp = last(["a", 1, true, /r/g]);
-const test5: number = last([1]);
+const test1: number | undefined = last([1, 2, 3, 4, 5]);
+const test2: number[] | undefined = last([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+const test3: { d: number } | undefined = last([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+const test4: RegExp | undefined = last(["a", 1, true, /r/g]);
+const test5: number | undefined = last([1]);
 const test6: undefined = last([]);
 
 // make sure it works with readonly arrays
@@ -14,10 +14,10 @@ const test7: 5 = last([1, 2, 3, 4, 5] as const);
 // make sure it works with dynamic arrays and not just static ones
 const dynArr = [1, 2, 3];
 dynArr.push(4);
-const test8: number = last(dynArr);
+const test8: number | undefined = last(dynArr);
 const dynArr2: (number | string)[] = [1, 2];
 dynArr2.push("hi");
-const test9: number | string = last(dynArr2);
+const test9: number | string | undefined = last(dynArr2);
 
 // Not OK
 // @ts-expect-error


### PR DESCRIPTION
It's possible for array-last to return `undefined`, so it should be included in the return type. If there's a more sophisticated typing that makes sense here i'm happy to change it

✔️ Updated tests and `yarn test-types` passes