### PR TITLE
Update compare types to work when the input is a generic

### DIFF
--- a/packages/collection-compare/index.d.ts
+++ b/packages/collection-compare/index.d.ts
@@ -4,14 +4,14 @@ type Primitive = boolean | string | number | bigint | null | undefined;
 
 declare function compare<T extends Primitive>(value1: T, value2: T): boolean;
 
-declare function compare<T1 extends object, T2 extends T1>(
-  value1: Exclude<T1, Primitive>,
-  value2: Exclude<T2, Primitive>
+declare function compare<T1 extends object, T2 extends object & T1>(
+  value1: T1,
+  value2: T2
 ): boolean;
 
-declare function compare<T1 extends T2, T2 extends object>(
-  value1: Exclude<T1, Primitive>,
-  value2: Exclude<T2, Primitive>
+declare function compare<T1 extends object & T2, T2 extends object>(
+  value1: T1,
+  value2: T2
 ): boolean;
 
 export default compare;

--- a/packages/collection-compare/index.tests.ts
+++ b/packages/collection-compare/index.tests.ts
@@ -45,6 +45,7 @@ compare(obj1, { b: 3, a: 2 });
 compare([1, [2, { a: 4 }], 4], [1, [2, { a: 4 }]]);
 compare([1, [2, { a: 4 }], 4], [1, [2, { a: 4 }], 4]);
 compare(NaN, NaN);
+const compareIt = <T extends object>(a: T, b: T) => compare(a, b);
 
 // Not okay
 // @ts-expect-error
@@ -59,6 +60,10 @@ compare({ a: 1, b: 2 }, [{ a: 1, b: 2 }]);
 compare(obj2, obj1);
 // @ts-expect-error
 compare(obj1, obj2);
+// @ts-expect-error
+compare(obj1, num1);
+// @ts-expect-error
+compare(num1, obj1);
 // @ts-expect-error
 compare(NaN, "abc");
 // @ts-expect-error

--- a/packages/collection-compare/package.json
+++ b/packages/collection-compare/package.json
@@ -6,6 +6,7 @@
   "module": "index.mjs",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "default": "./index.mjs"
     }


### PR DESCRIPTION
Fixes #460. 

The solution to this ended up being slightly more complex than I thought, because the final two test cases check that it is a type error to compare a `Number` to a `number`

There's some weird non-transitive `extends` behavior here , which is why the original `Exclude<T, Primitive>` was used.

- `Number extends object` = true
- `number extends Number` = true
- `number extends object` = false

So I changed the type parameters to `compare<T1 extends object, T2 extends T1 & object>`, which keeps the tests passing while also allowing it to work with generic arguments.


I also added the `types` entry to the export map for compatibility with TS 4.7 node16/nodenext module resolution.