### PR TITLE
Add generic for object-merge type

### DIFF
--- a/packages/object-merge/index.d.ts
+++ b/packages/object-merge/index.d.ts
@@ -1,3 +1,6 @@
 // Definitions by: nokazn <https://github.com/nokazn>
-declare function merge(obj1: object, ...objs: object[]): object;
+declare function merge<
+  TObj1 extends object = object,
+  TObjs extends object = object
+>(obj1: TObj1, ...objs: TObjs[]): TObj1 & TObjs;
 export default merge;

--- a/packages/object-merge/index.tests.ts
+++ b/packages/object-merge/index.tests.ts
@@ -9,6 +9,7 @@ merge([]);
 merge(() => {});
 merge(new Map());
 merge(new Set());
+merge<{ a: number; b: number; }>({ a: 1, b: 2 });
 
 // Multiple arguments
 merge({}, {});
@@ -18,6 +19,10 @@ merge({}, () => {});
 merge({}, new Map());
 merge({}, new Set());
 merge({}, { a: 1 }, { a: 2, b: 3 });
+merge<{ a: number; b: number; }, { a: number; b: number; c: number; }>(
+  { a: 4, b: 8 },
+  { a: 6, b: 1, c: 8 }
+);
 
 // Not OK
 
@@ -36,6 +41,8 @@ merge(null);
 merge(undefined);
 // @ts-expect-error
 merge(Symbol());
+// @ts-expect-error
+merge<{ a: string; b: string; }>({ a: 1, b: 2 });
 
 // Multiple arguments
 // @ts-expect-error
@@ -52,3 +59,5 @@ merge({}, undefined);
 merge({}, Symbol());
 // @ts-expect-error
 merge({}, {}, null);
+// @ts-expect-error
+merge<{ a: string; b: string; }, { a: string; b: string; c: string; }>({ a: 4, b: 8 }, { a: 6, b: 1, c: 8 });


### PR DESCRIPTION
This improves the flexibility of the `merge` utility!

Updated tests and `test-types` passes.

Before, the return and props of the merge utility would always be just an object type.

:x: Not good.
![just-merge-before-eg](https://user-images.githubusercontent.com/61118233/178268222-7ebcfb92-7524-4baf-9614-1e2a09dabe93.png)

Now using generics, typescript can figure out the return and props types.

:heavy_check_mark: Good!
![just-merge-generic-eg](https://user-images.githubusercontent.com/61118233/178270736-b7021ed8-93e1-4602-a63a-ac37db74e8da.png)

