### PR TITLE
Add typings for function-demethodize

### DIFF
--- a/packages/function-demethodize/index.d.ts
+++ b/packages/function-demethodize/index.d.ts
@@ -1,0 +1,13 @@
+declare function demethodize<Entity, MethodName extends keyof Entity>(
+  method: Entity[MethodName] & Function
+): Entity[MethodName] extends (...p: any[]) => any
+  ? (
+      p: Entity,
+      ...args: Parameters<Entity[MethodName]>
+    ) => ReturnType<Entity[MethodName]>
+  : never;
+declare function demethodize<Entity, Params extends any[], Returns>(
+  method: (...p: Params) => Returns
+): (p: Entity, ...a: Params) => Returns;
+
+export default demethodize;

--- a/packages/function-demethodize/index.tests.ts
+++ b/packages/function-demethodize/index.tests.ts
@@ -1,0 +1,22 @@
+import demethodize from "./index";
+
+//OK
+
+const test1: (p: string) => string = demethodize("".trim);
+const test2 = demethodize<string, "big">("".big);
+const test3 = demethodize<number, "toFixed">((1).toFixed);
+const test4 = demethodize<Object, "toString">({}.toString);
+const test5 = demethodize<any[], "map">([].map);
+const test6 = demethodize<string, [string], string[]>("".split);
+
+// Not OK
+// @ts-expect-error
+demethodize<string, "trim">();
+// @ts-expect-error
+demethodize<number, "valueOf">((1).toExponential);
+// @ts-expect-error
+demethodize<boolean, "valueOf">([].toString);
+// @ts-expect-error
+demethodize<number[], "length">([].length);
+// @ts-expect-error
+demethodize<string>("".trim);

--- a/packages/function-demethodize/package.json
+++ b/packages/function-demethodize/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.1",
   "description": "turn a method into a standalone function; the first arg becomes `this`",
   "main": "index.js",
+  "types": "index.d.ts",
   "module": "index.mjs",
   "exports": {
     ".": {


### PR DESCRIPTION
I think this is the last package that needed typings. 

Currently there are 2 signatures you can call this with:

```ts
demethodize<string, [string], string>("".split);
//OR
demethodize<string, "split">("".split);
```

The best way to use this in my opinion is to specify the function typing on the variable you assign the function too, as such:

```ts
const split: (p:string, a:string) => string[] = demethodize("".split)
```

Unfortunately, you have to manually pass generics to this function in order to use it (unless you use the method shown directly above). This is because when you call `demethodize("".split)` typescript has no way of knowing what type you called the `.split` method on.

I wasn't able to get the generics working exactly how I wanted to, ideally, you would only have to specify the type that you are pulling the method from, and then it could auto infer the rest, eg;

```ts
demethodize<string>("".split)
```

Would infer the function signature `(p:string, a:string) => string[]`, however, I don't think that is currently possible because of the way that type inference works with default values for generics.

**Edit:** I just noticed that my prettier config may have messed with the formatting of the files, I wasn't able to run eslint to format any typescript files. Seems like eslint is not configured to fix the typescript files.