### PR TITLE
Pass group keys as generics in array-group-by

### DIFF
--- a/packages/array-group-by/index.d.ts
+++ b/packages/array-group-by/index.d.ts
@@ -3,4 +3,7 @@
  * @param arr the array to group
  * @param resolver function used to resolve group key
  */
-export default function groupBy<T>(arr: T[], resolver: (arg: T) => keyof any): Record<keyof any, T[]>
+export default function groupBy<T, G extends keyof any = keyof any>(
+  arr: T[],
+  resolver: (arg: T) => G
+): Record<G, T[]>;

--- a/packages/array-group-by/index.tests.ts
+++ b/packages/array-group-by/index.tests.ts
@@ -1,12 +1,25 @@
-import groupBy from './index'
+import groupBy from "./index";
 
 // OK
 const test1: { [key: string]: number[] } = groupBy([6.1, 4.2, 6.3], Math.floor);
-const test2: { [key: string]: string[] } = groupBy(['a', 'b', 'c', 'aa', 'bb', 'cc'], str => str.charAt(0));
-const test3: { [key: string]: number[][] } = groupBy([[1], [2], [1, 2]], arr => arr.length);
+const test2: { [key: string]: string[] } = groupBy(
+  ["a", "b", "c", "aa", "bb", "cc"],
+  str => str.charAt(0)
+);
+const test3: { [key: string]: number[][] } = groupBy(
+  [[1], [2], [1, 2]],
+  arr => arr.length
+);
 const test4: {} = groupBy([], () => "a");
-const test5: { [key: string]: Array<number | string>} = groupBy([1, 2, 3, "1", "2"], (a) => a);
-const test6 = groupBy(['a', 'b', 'c'], str => Symbol(str));
+const test5: { [key: string]: Array<number | string> } = groupBy(
+  [1, 2, 3, "1", "2"],
+  a => a
+);
+const test6 = groupBy(["a", "b", "c"], str => Symbol(str));
+type K = "a" | "b";
+const test7: Record<K, number[]> = groupBy([1, 2, 3], v =>
+  v % 2 === 0 ? "a" : "b"
+);
 
 // Not OK
 // @ts-expect-error
@@ -16,7 +29,7 @@ groupBy();
 // @ts-expect-error
 groupBy({}, Math.floor);
 // @ts-expect-error
-groupBy('hello', Math.floor);
+groupBy("hello", Math.floor);
 // @ts-expect-error
 groupBy(/hullo/, Math.floor);
 // @ts-expect-error
@@ -25,7 +38,7 @@ groupBy(null, Math.floor);
 groupBy(undefined, Math.floor);
 
 // @ts-expect-error
-groupBy(["a", "b", "c"], () => { });
+groupBy(["a", "b", "c"], () => {});
 // @ts-expect-error
 groupBy(["a", "b", "c"], Math.floor);
 // @ts-expect-error
@@ -42,3 +55,5 @@ groupBy([], null);
 groupBy([], undefined);
 // @ts-expect-error
 groupBy([]);
+// @ts-expect-error
+groupBy<any, "good key">([], () => "bad key");


### PR DESCRIPTION
This change allows for more strict typing to be used with the function but will default to the standard way it worked originally.