### PR TITLE
Simplifies typings on `just-compare`

### DIFF
--- a/packages/collection-compare/index.d.ts
+++ b/packages/collection-compare/index.d.ts
@@ -1,17 +1,3 @@
-// Definitions by: Justy Robles <https://github.com/justyrobles>
-
-type Primitive = boolean | string | number | bigint | null | undefined;
-
-declare function compare<T extends Primitive>(value1: T, value2: T): boolean;
-
-declare function compare<T1 extends object, T2 extends object & T1>(
-  value1: T1,
-  value2: T2
-): boolean;
-
-declare function compare<T1 extends object & T2, T2 extends object>(
-  value1: T1,
-  value2: T2
-): boolean;
+declare function compare(value1: unknown, value2: unknown): boolean;
 
 export default compare;

--- a/packages/collection-compare/index.tests.ts
+++ b/packages/collection-compare/index.tests.ts
@@ -50,27 +50,3 @@ const compareIt = <T extends object>(a: T, b: T) => compare(a, b);
 // Not okay
 // @ts-expect-error
 compare();
-// @ts-expect-error
-compare(1, "1");
-// @ts-expect-error
-compare(["abc"], "abc");
-// @ts-expect-error
-compare({ a: 1, b: 2 }, [{ a: 1, b: 2 }]);
-// @ts-expect-error
-compare(obj2, obj1);
-// @ts-expect-error
-compare(obj1, obj2);
-// @ts-expect-error
-compare(obj1, num1);
-// @ts-expect-error
-compare(num1, obj1);
-// @ts-expect-error
-compare(NaN, "abc");
-// @ts-expect-error
-compare(funcA, funcB);
-// @ts-expect-error
-compare(funcA, true);
-// @ts-expect-error
-compare(num1, num2);
-// @ts-expect-error
-compare(num2, num1);


### PR DESCRIPTION
Fixes https://github.com/angus-c/just/issues/476

- Typings now just take 2 values of unknown type & returns a boolean, which matches the JS