### PR TITLE
fix package.json comply with Webpack 5 rule

### DIFF
--- a/packages/function-debounce/package.json
+++ b/packages/function-debounce/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
fix export for webpack 'enhanced-resolve' rule, default condition can only be the last one: https://github.com/webpack/enhanced-resolve/blob/02d99a2e6852adaf43fecfc3fed14d8d5c8df10b/lib/util/entrypoints.js#L455