### PR TITLE
fix: reorder exports to set default last

### DIFF
--- a/packages/array-cartesian-product/package.json
+++ b/packages/array-cartesian-product/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-compact/package.json
+++ b/packages/array-compact/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-flatten/package.json
+++ b/packages/array-flatten/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-group-by/package.json
+++ b/packages/array-group-by/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-index/package.json
+++ b/packages/array-index/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-insert/package.json
+++ b/packages/array-insert/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-intersect/package.json
+++ b/packages/array-intersect/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-last/package.json
+++ b/packages/array-last/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-mean/package.json
+++ b/packages/array-mean/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-median/package.json
+++ b/packages/array-median/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-mode/package.json
+++ b/packages/array-mode/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-partition/package.json
+++ b/packages/array-partition/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-percentile/package.json
+++ b/packages/array-percentile/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-permutations/package.json
+++ b/packages/array-permutations/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-random/package.json
+++ b/packages/array-random/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-range/package.json
+++ b/packages/array-range/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-remove/package.json
+++ b/packages/array-remove/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-shuffle/package.json
+++ b/packages/array-shuffle/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-skewness/package.json
+++ b/packages/array-skewness/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-sort-by/package.json
+++ b/packages/array-sort-by/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-split-at/package.json
+++ b/packages/array-split-at/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-split/package.json
+++ b/packages/array-split/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-standard-deviation/package.json
+++ b/packages/array-standard-deviation/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-tail/package.json
+++ b/packages/array-tail/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-union/package.json
+++ b/packages/array-union/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-unique/package.json
+++ b/packages/array-unique/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-variance/package.json
+++ b/packages/array-variance/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/array-zip/package.json
+++ b/packages/array-zip/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/collection-clone/package.json
+++ b/packages/collection-clone/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/collection-diff-apply/package.json
+++ b/packages/collection-diff-apply/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/collection-diff/package.json
+++ b/packages/collection-diff/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/collection-flush/package.json
+++ b/packages/collection-flush/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/collection-pluck/package.json
+++ b/packages/collection-pluck/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-compose/package.json
+++ b/packages/function-compose/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-curry/package.json
+++ b/packages/function-curry/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-debounce/package.json
+++ b/packages/function-debounce/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-demethodize/package.json
+++ b/packages/function-demethodize/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-flip/package.json
+++ b/packages/function-flip/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-memoize-last/package.json
+++ b/packages/function-memoize-last/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-memoize/package.json
+++ b/packages/function-memoize/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-once/package.json
+++ b/packages/function-once/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-partial/package.json
+++ b/packages/function-partial/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/function-throttle/package.json
+++ b/packages/function-throttle/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/number-clamp/package.json
+++ b/packages/number-clamp/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/number-in-range/package.json
+++ b/packages/number-in-range/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/number-is-prime/package.json
+++ b/packages/number-is-prime/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/number-modulo/package.json
+++ b/packages/number-modulo/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/number-random-integer/package.json
+++ b/packages/number-random-integer/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-deep-map-values/package.json
+++ b/packages/object-deep-map-values/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-entries/package.json
+++ b/packages/object-entries/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-extend/package.json
+++ b/packages/object-extend/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-filter/package.json
+++ b/packages/object-filter/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-flip/package.json
+++ b/packages/object-flip/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-has/package.json
+++ b/packages/object-has/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-is-circular/package.json
+++ b/packages/object-is-circular/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-is-empty/package.json
+++ b/packages/object-is-empty/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-is-primitive/package.json
+++ b/packages/object-is-primitive/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-map-keys/package.json
+++ b/packages/object-map-keys/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-map-values/package.json
+++ b/packages/object-map-values/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-map/package.json
+++ b/packages/object-map/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-merge/package.json
+++ b/packages/object-merge/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-omit/package.json
+++ b/packages/object-omit/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-pick/package.json
+++ b/packages/object-pick/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-reduce/package.json
+++ b/packages/object-reduce/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-safe-get/package.json
+++ b/packages/object-safe-get/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-safe-set/package.json
+++ b/packages/object-safe-set/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-typeof/package.json
+++ b/packages/object-typeof/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/object-values/package.json
+++ b/packages/object-values/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-camel-case/package.json
+++ b/packages/string-camel-case/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-capitalize/package.json
+++ b/packages/string-capitalize/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-kebab-case/package.json
+++ b/packages/string-kebab-case/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-left-pad/package.json
+++ b/packages/string-left-pad/package.json
@@ -8,8 +8,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-pascal-case/package.json
+++ b/packages/string-pascal-case/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-prune/package.json
+++ b/packages/string-prune/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-replace-all/package.json
+++ b/packages/string-replace-all/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-right-pad/package.json
+++ b/packages/string-right-pad/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-snake-case/package.json
+++ b/packages/string-snake-case/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-squash/package.json
+++ b/packages/string-squash/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-template/package.json
+++ b/packages/string-template/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/string-truncate/package.json
+++ b/packages/string-truncate/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "default": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
From #486 and the [NodeJS docs](https://nodejs.org/api/packages.html#conditional-exports), the `default` entry should always be last. Bug introduced in #484

For posterity, this is the code I used to fix this:

```js
import { readdir, readFile, writeFile } from 'node:fs/promises'
import { join } from 'node:path'
const ROOT = 'packages'
const dirs = await readdir(ROOT)
for (const dir of dirs) {
	const filepath = join(ROOT, dir, 'package.json')
	const pkg = JSON.parse(await readFile(filepath))
	const { default: d, ...remaining } = pkg.exports['.']
	pkg.exports['.'] = { ...remaining, default: d }
	writeFile(filepath, JSON.stringify(pkg, undefined, 2), 'utf8')
}
```