### PR TITLE
Add code highlight to first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A [REPL](https://anguscroll.com/just) for every utility (powered by [RunKit](htt
 ## ES and CJS modules available for every utility <img src="images/esm.png" width="22"/> <img src="images/node.jpeg" width="18"/>
 
 All packages support ES module or Common JS syntax without requiring transpilation
-```
+```js
 // esm (node / bundler)
 import clone from 'just-clone'; 
 


### PR DESCRIPTION
On the first example, there is a code highlight missing: just made sure it works specifying `js` as code used there.