### PR TITLE
Fix typings for object-reduce(use default export)

### DIFF
--- a/packages/object-reduce/index.d.ts
+++ b/packages/object-reduce/index.d.ts
@@ -1,8 +1,10 @@
 type Predicate<T extends object, Acc> =
   (acc: Acc, key: keyof T, value: T[keyof T], index: number, keys: Array<keyof T>) => Acc
 
-export function reduce<T extends object, Acc>(
+declare function reduce<T extends object, Acc>(
   obj: T,
   predicate: Predicate<T, Acc>,
   initialValue?: Acc
 ): Acc
+
+export default reduce

--- a/packages/object-reduce/index.tests.ts
+++ b/packages/object-reduce/index.tests.ts
@@ -1,4 +1,4 @@
-import { reduce } from './index';
+import reduce from './index';
 
 const obj = { a: 3, b: 4, c: 9 };
 


### PR DESCRIPTION
Changed to use default export in typings.