### PR TITLE
Replace `object` type with `Record<keyof any, unknown>` in object-* packages

### DIFF
--- a/packages/object-entries/index.d.ts
+++ b/packages/object-entries/index.d.ts
@@ -1,2 +1,2 @@
 export default function entries<T extends any[]>(obj: T): [number, T[number]][];
-export default function entries<T extends object>(obj: T): [keyof T, T[keyof T]][];
+export default function entries<T extends Record<keyof any, unknown>>(obj: T): [keyof T, T[keyof T]][];

--- a/packages/object-extend/index.d.ts
+++ b/packages/object-extend/index.d.ts
@@ -1,4 +1,4 @@
 // Definitions by: Peter Safranek <https://github.com/pe8ter>
-declare function extend(obj1: object, ...objn: any[]): object;
-declare function extend(deep: boolean, obj1: object, ...objn: any[]): object;
+declare function extend(obj1: Record<keyof any, string>, ...objn: any[]): Record<keyof any, string>;
+declare function extend(deep: boolean, obj1: Record<keyof any, string>, ...objn: any[]): Record<keyof any, string>;
 export default extend;

--- a/packages/object-extend/index.tests.ts
+++ b/packages/object-extend/index.tests.ts
@@ -4,8 +4,6 @@ import extend from './index'
 
 // Pass single `object`.
 extend({});
-extend([]);
-extend(() => {});
 
 // Pass single `object`, then `any`.
 extend({}, 0);
@@ -22,8 +20,6 @@ extend({}, 0, "", false, null, undefined, {}, [], () => {});
 
 // Pass `boolean`, then single `object`.
 extend(true, {});
-extend(true, []);
-extend(true, () => {});
 
 // Pass `boolean`, single `object`, then `any`.
 extend(true, {}, 0);
@@ -51,6 +47,10 @@ extend("");
 extend(false);
 // @ts-expect-error
 extend();
+// @ts-expect-error
+extend([]);
+// @ts-expect-error
+extend(() => {});
 
 // @ts-expect-error
 extend(true, 0);
@@ -60,3 +60,7 @@ extend(true, "");
 extend(true, false);
 // @ts-expect-error
 extend(true);
+// @ts-expect-error
+extend(true, []);
+// @ts-expect-error
+extend(true, () => {});

--- a/packages/object-filter/index.d.ts
+++ b/packages/object-filter/index.d.ts
@@ -1,9 +1,6 @@
-type PlainObject<T> = T extends Map<any, any> | Set<any> | null ? never :
-  T extends object ? T :
-  never;
+declare function filter<Arg extends keyof any, K extends Arg, V>(
+  obj: Record<K, V>,
+  fn: (key: Arg, value: V) => boolean
+): Partial<Record<K, V>>;
 
-declare function filter<T>(
-  obj: PlainObject<T>,
-  fn: (key: keyof T, value: T[typeof key]) => any
-): Partial<T>;
 export default filter;

--- a/packages/object-has/index.d.ts
+++ b/packages/object-has/index.d.ts
@@ -1,3 +1,6 @@
 // Definitions by: daniel0mullins <https://github.com/daniel0mullins>
-declare function has(obj: object | undefined, propsArg: Array<string> | Symbol | string): boolean;
+declare function has(
+  obj: Record<keyof any, unknown> | undefined,
+  propsArg: Array<string> | Symbol | string
+): boolean;
 export default has;

--- a/packages/object-map-keys/index.d.ts
+++ b/packages/object-map-keys/index.d.ts
@@ -1,6 +1,6 @@
 // Definitions by: Aryaman1706 <https://github.com/Aryaman1706>
-declare function map<T extends object = object>(
+declare function map<T extends Record<keyof any, unknown>>(
   obj: T,
-  predicate: (value: any, key: string | number, object: T) => string | number
-): object;
+  predicate: (value: T[keyof T], key: keyof T, object: T) => keyof any
+): Record<ReturnType<typeof predicate>, T[keyof T]>;
 export default map;

--- a/packages/object-merge/index.d.ts
+++ b/packages/object-merge/index.d.ts
@@ -1,6 +1,6 @@
 // Definitions by: nokazn <https://github.com/nokazn>
 declare function merge<
-  TObj1 extends object = object,
-  TObjs extends object = object
+  TObj1 extends Record<keyof any, unknown>,
+  TObjs extends Record<keyof any, unknown>
 >(obj1: TObj1, ...objs: TObjs[]): TObj1 & TObjs;
 export default merge;

--- a/packages/object-merge/index.tests.ts
+++ b/packages/object-merge/index.tests.ts
@@ -5,19 +5,10 @@ import merge from "./index";
 // Single argument
 merge({});
 merge({ a: 1 });
-merge([]);
-merge(() => {});
-merge(new Map());
-merge(new Set());
-merge<{ a: number; b: number; }>({ a: 1, b: 2 });
 
 // Multiple arguments
 merge({}, {});
 merge({}, { a: 1 });
-merge({}, []);
-merge({}, () => {});
-merge({}, new Map());
-merge({}, new Set());
 merge({}, { a: 1 }, { a: 2, b: 3 });
 merge<{ a: number; b: number; }, { a: number; b: number; c: number; }>(
   { a: 4, b: 8 },
@@ -43,6 +34,14 @@ merge(undefined);
 merge(Symbol());
 // @ts-expect-error
 merge<{ a: string; b: string; }>({ a: 1, b: 2 });
+// @ts-expect-error
+merge([]);
+// @ts-expect-error
+merge(() => {});
+// @ts-expect-error
+merge(new Map());
+// @ts-expect-error
+merge(new Set());
 
 // Multiple arguments
 // @ts-expect-error
@@ -61,3 +60,11 @@ merge({}, Symbol());
 merge({}, {}, null);
 // @ts-expect-error
 merge<{ a: string; b: string; }, { a: string; b: string; c: string; }>({ a: 4, b: 8 }, { a: 6, b: 1, c: 8 });
+// @ts-expect-error
+merge({}, []);
+// @ts-expect-error
+merge({}, () => {});
+// @ts-expect-error
+merge({}, new Map());
+// @ts-expect-error
+merge({}, new Set());

--- a/packages/object-omit/index.d.ts
+++ b/packages/object-omit/index.d.ts
@@ -1,9 +1,9 @@
-declare function omit<Obj extends object, Key extends keyof Obj>(
+declare function omit<Obj extends Record<keyof any, unknown>, Key extends keyof Obj>(
   obj: Obj,
   remove: Key[]
 ): Omit<Obj, Key>;
 
-declare function omit<Obj extends object, Key extends keyof Obj>(
+declare function omit<Obj extends Record<keyof any, unknown>, Key extends keyof Obj>(
   obj: Obj,
   remove1: Key,
   ...removeN: Key[]


### PR DESCRIPTION
It is recommended to use `Record<string, unknown>` instead of `object` type. [Reference](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/ban-types.md#:~:text=Avoid%20the%20object%20type%2C%20as%20it%20is%20currently%20hard%20to%20use%20due%20to%20not%20being%20able%20to%20assert%20that%20keys%20exist).