### PR TITLE
Fix is-empty return type

### DIFF
--- a/packages/object-is-empty/index.d.ts
+++ b/packages/object-is-empty/index.d.ts
@@ -1,13 +1,10 @@
 type ReturnTrueValues = null | undefined | "" | [] | number | boolean | Symbol;
-type ReturnFalseValues = string | any[];
-type CheckValue = ReturnTrueValues | ReturnFalseValues | object;
+type CheckValue = ReturnTrueValues | object | string | any[];
 
 declare function isEmpty<T extends CheckValue>(
   obj: T
 ): T extends ReturnTrueValues
   ? true
-  : T extends ReturnFalseValues
-  ? false
   : boolean;
 
 export default isEmpty;

--- a/packages/object-is-empty/index.tests.ts
+++ b/packages/object-is-empty/index.tests.ts
@@ -6,17 +6,17 @@ import isEmpty from "./index";
 const test1: true = isEmpty(null);
 const test2: true = isEmpty(undefined);
 const test3: true = isEmpty([]);
-const test4: false = isEmpty([1, 2]);
-const test5: false = isEmpty("abc");
-const test6: true = isEmpty("");
-const test7: true = isEmpty(0);
-const test8: true = isEmpty(1);
-const test9: true = isEmpty(true);
-const test10: true = isEmpty(false);
-const test11: true = isEmpty(Symbol("abc"));
-const test12: true = isEmpty(Symbol(""));
+const test4: true = isEmpty("");
+const test5: true = isEmpty(0);
+const test6: true = isEmpty(1);
+const test7: true = isEmpty(true);
+const test8: true = isEmpty(false);
+const test9: true = isEmpty(Symbol("abc"));
+const test10: true = isEmpty(Symbol(""));
 
 // Unknown
+const test11: boolean = isEmpty([1, 2]);
+const test12: boolean = isEmpty("abc");
 const test13: boolean = isEmpty({ a: 3, b: 5 });
 const test14: boolean = isEmpty(new Set([1, 2, 2]));
 const test15: boolean = isEmpty(new Map().set("a", 2));


### PR DESCRIPTION
I think the idea was for `ReturnFalseValues` to represent values that could return false, but the effect is that the type checker sees these as "always returns false". Really, `string` and `any[]` should be in the same category as `object` and should be treated as "needs further inspection"