### PR TITLE
Fix incorrect code snippet description for `just-index`

### DIFF
--- a/packages/array-index/README.md
+++ b/packages/array-index/README.md
@@ -24,6 +24,6 @@ index([{id: 'first', val: 1}, {id: 'second', val: 2}], 'id');
 // {first: {id: 'first', val: 1}, second: {id: 'second', val: 2}}
 index([{id: 'first', val: 1}, null], 'id'); // {first: {id: 'first', val: 1}}
 index([], 'id'); // {}
-index([], null); // undefined
-index({}, 'id'); // undefined
+index([], null); // throws error
+index({}, 'id'); // throws error
 ```


### PR DESCRIPTION
Updated the readme file for `just-index` to reflect that the code snippet throws an error instead of returning undefined, which was originally stated. This change ensures that the code snippet description is accurate and helpful for developers.

**Code snippet:**
```js
index([], null);	// throws error
index({}, 'id');	// throws error
```

**URL:**
- https://anguscroll.com/just/just-index