### PR TITLE
Add readonly array support to just-random

### DIFF
--- a/packages/array-random/index.d.ts
+++ b/packages/array-random/index.d.ts
@@ -1,3 +1,3 @@
 declare function random<Head, Rest>(arr: [Head, ...Rest[]]): Head | Rest;
-declare function random<T>(arr: T[]): T | undefined;
+declare function random<T>(arr: readonly T[]): T | undefined;
 export default random;

--- a/packages/array-random/index.tests.ts
+++ b/packages/array-random/index.tests.ts
@@ -7,6 +7,8 @@ const test3: number = random([1, 2, 3]);
 const test4: number | string = random([1, 2, "a"]);
 const numbers: number[] = [];
 const test5: number | undefined = random(numbers);
+const readonlyNumbers: readonly number[] = [1, 2, 3];
+const test6: number | undefined = random(readonlyNumbers);
 
 // Not OK
 // @ts-expect-error


### PR DESCRIPTION
Add readonly array support and corresponding test to just-random.

This pull request is related to #549.