### PR TITLE
(fix)[flatten-array]: Enable Flattening of all nested arrays in the array

### DIFF
--- a/packages/array-flatten/index.cjs
+++ b/packages/array-flatten/index.cjs
@@ -7,20 +7,32 @@ module.exports = flatten;
 
 function flattenHelper(arr, depth) {
   var stack = arr.slice();
-  var result = [];
+  var stackContainsArray = false;
 
-  while (stack.length) {
-    var item = stack.pop();
-
-    if (Array.isArray(item) && depth > 0) {
-      stack.push.apply(stack, item);
-      depth--;
-    } else {
-      result.push(item);
+  for (var i=0; i<stack.length; i++) {
+    if (Array.isArray(stack[i])) {
+      stackContainsArray = true;
     }
   }
 
-  return result.reverse();
+  for (; depth > 0 && stackContainsArray; depth--) {
+    stackContainsArray = false;
+    var nextStack = []
+
+    while (stack.length) {
+      var item = stack.shift();
+      if (Array.isArray(item)) {
+        stackContainsArray = true;
+        nextStack.push.apply(nextStack, item);
+      } else {
+        nextStack.push(item);
+      }
+    }
+
+    stack = nextStack;
+  }
+
+  return stack;
 }
 
 function flatten(arr, depth) {

--- a/packages/array-flatten/index.cjs
+++ b/packages/array-flatten/index.cjs
@@ -9,9 +9,10 @@ function flattenHelper(arr, depth) {
   var stack = arr.slice();
   var stackContainsArray = false;
 
-  for (var i=0; i<stack.length; i++) {
+  for (var i = 0; i < stack.length; i++) {
     if (Array.isArray(stack[i])) {
       stackContainsArray = true;
+      break;
     }
   }
 

--- a/packages/array-flatten/index.cjs
+++ b/packages/array-flatten/index.cjs
@@ -7,14 +7,7 @@ module.exports = flatten;
 
 function flattenHelper(arr, depth) {
   var stack = arr.slice();
-  var stackContainsArray = false;
-
-  for (var i = 0; i < stack.length; i++) {
-    if (Array.isArray(stack[i])) {
-      stackContainsArray = true;
-      break;
-    }
-  }
+  var stackContainsArray = true;
 
   for (; depth > 0 && stackContainsArray; depth--) {
     stackContainsArray = false;

--- a/packages/array-flatten/index.mjs
+++ b/packages/array-flatten/index.mjs
@@ -7,20 +7,32 @@ var arrayFlatten = flatten;
 
 function flattenHelper(arr, depth) {
   var stack = arr.slice();
-  var result = [];
+  var stackContainsArray = false;
 
-  while (stack.length) {
-    var item = stack.pop();
-
-    if (Array.isArray(item) && depth > 0) {
-      stack.push.apply(stack, item);
-      depth--;
-    } else {
-      result.push(item);
+  for (var i=0; i<stack.length; i++) {
+    if (Array.isArray(stack[i])) {
+      stackContainsArray = true;
     }
   }
 
-  return result.reverse();
+  for (; depth > 0 && stackContainsArray; depth--) {
+    stackContainsArray = false;
+    var nextStack = [];
+
+    while (stack.length) {
+      var item = stack.shift();
+      if (Array.isArray(item)) {
+        stackContainsArray = true;
+        nextStack.push.apply(nextStack, item);
+      } else {
+        nextStack.push(item);
+      }
+    }
+
+    stack = nextStack;
+  }
+
+  return stack;
 }
 
 function flatten(arr, depth) {

--- a/packages/array-flatten/index.mjs
+++ b/packages/array-flatten/index.mjs
@@ -9,9 +9,10 @@ function flattenHelper(arr, depth) {
   var stack = arr.slice();
   var stackContainsArray = false;
 
-  for (var i=0; i<stack.length; i++) {
+  for (var i = 0; i < stack.length; i++) {
     if (Array.isArray(stack[i])) {
       stackContainsArray = true;
+      break;
     }
   }
 

--- a/packages/array-flatten/index.mjs
+++ b/packages/array-flatten/index.mjs
@@ -7,14 +7,7 @@ var arrayFlatten = flatten;
 
 function flattenHelper(arr, depth) {
   var stack = arr.slice();
-  var stackContainsArray = false;
-
-  for (var i = 0; i < stack.length; i++) {
-    if (Array.isArray(stack[i])) {
-      stackContainsArray = true;
-      break;
-    }
-  }
+  var stackContainsArray = true;
 
   for (; depth > 0 && stackContainsArray; depth--) {
     stackContainsArray = false;

--- a/test/array-flatten/index.cjs
+++ b/test/array-flatten/index.cjs
@@ -40,12 +40,12 @@ test('returns a new array with all sub-arrays items concatenated into it up to t
   function(t) {
     t.plan(5);
 
-    var arr = [1, [2, [3, [4, [5]]]]];
+    var arr = [[1, [2, 3], 4], [5, [6, [7, [8]]]]];
     t.deepEqual(flatten(arr, 0), arr);
-    t.deepEqual(flatten(arr, 1), [1, 2, [3, [4, [5]]]]);
-    t.deepEqual(flatten(arr, 2), [1, 2, 3, [4, [5]]]);
-    t.deepEqual(flatten(arr, 3), [1, 2, 3, 4, [5]]);
-    t.deepEqual(flatten(arr, 4), [1, 2, 3, 4, 5]);
+    t.deepEqual(flatten(arr, 1), [1, [2, 3], 4, 5, [6, [7, [8]]]]);
+    t.deepEqual(flatten(arr, 2), [1, 2, 3, 4, 5, 6, [7, [8]]]);
+    t.deepEqual(flatten(arr, 3), [1, 2, 3, 4, 5, 6, 7, [8]]);
+    t.deepEqual(flatten(arr, 4), [1, 2, 3, 4, 5, 6, 7, 8]);
 
     t.end();
   });


### PR DESCRIPTION
Fixes: https://github.com/angus-c/just/issues/564

Algorithm:
```
- Loop over depth till depth becomes 0
 - if in any iteration the depth > 0 but array does not contain any array as its element, then break
 - Iterate over the current array and if the current element is not an array, simply push it to next stack otherwise unwrap the array of one depth and then push the unwrapped array into next stack array
```

Dry Run:

Input Sample 1:
Input Array = `[[1, [2, 3], 4], [5, [6, [7, [8]]]]]`;
Depth = `6`;
Result = `[1, 2, 3, 4, 5, 6, 7, 8]`;

| Depth | Array At Start of Iteration | Array At End of Iteration |
|-------|--------------------------|--------------------------|
| 6 | `[[1, [2, 3], 4], [5, [6, [7, [8]]]]]` | `[1, [2, 3], 4, 5, [6, [7, [8]]]]` |
| 5 | `[1, [2, 3], 4, 5, [6, [7, [8]]]]` | `[1, 2, 3, 4, 5, 6, [7, [8]]]` |
| 4 | `[1, 2, 3, 4, 5, 6, [7, [8]]]` | `[1, 2, 3, 4, 5, 6, 7, [8]]` |
| 3 | `[1, 2, 3, 4, 5, 6, 7, [8]]` | `[1, 2, 3, 4, 5, 6, 7, 8]` |
| 2 | `[1, 2, 3, 4, 5, 6, 7, 8]`  | `[1, 2, 3, 4, 5, 6, 7, 8]` |
| 1 | `[1, 2, 3, 4, 5, 6, 7, 8]` (break Due to Array containing no array) | |

Input Sample 2:
Input Array = `[[1, [2, 3], 4], [5, [6, [7, [8]]]]]`;
Depth = `3`;
Result = `[1, 2, 3, 4, 5, 6, 7, [8]]`;

| Depth | Array At Start of Iteration | Array At End of Iteration |
|-------|--------------------------|--------------------------|
| 3 | `[[1, [2, 3], 4], [5, [6, [7, [8]]]]]` | `[1, [2, 3], 4, 5, [6, [7, [8]]]]` |
| 2 | `[1, [2, 3], 4, 5, [6, [7, [8]]]]` | `[1, 2, 3, 4, 5, 6, [7, [8]]]` |
| 1 | `[1, 2, 3, 4, 5, 6, [7, [8]]]` | `[1, 2, 3, 4, 5, 6, 7, [8]]` |
| 0 | `[1, 2, 3, 4, 5, 6, 7, [8]]` (break Due to depth === 0) | |