### PR TITLE
Improve type for just-clone to accept primitives too

### DIFF
--- a/packages/collection-clone/index.d.ts
+++ b/packages/collection-clone/index.d.ts
@@ -1,3 +1,3 @@
 // Definitions by: Chris Howard <https://github.com/ConnectivityChris>
-declare function clone<T extends object>(obj: T): T;
+declare function clone<T>(obj: T): T;
 export default clone;


### PR DESCRIPTION
The TypeScript types for just-clone say that the input must be an object, but if you look at the code that's not true, it works fine with a primitive as well. So maybe the type should just be `T` rather than `T extends object`. This is what lodash uses for cloneDeep.

Alternatively all the primitives could be specified like `T | number | string | ...` but if `T` is good enough for lodash it's probably good enough here too.