### PR TITLE
Add function override, support narrowing when using a type guard as the resolver function

### DIFF
--- a/packages/array-partition/index.d.ts
+++ b/packages/array-partition/index.d.ts
@@ -11,4 +11,6 @@
  * partition(['a', 1, 2, 'b'], x => typeof x == 'string');
  * // => [['a', 'b'], [1, 2]]
  */
-export default function partition<T>(arr: T[], resolver: (arg: T) => boolean): [T[], T[]]
+declare function partition<T, S extends T>(arr: T[], resolver: (arg: T) => arg is S): [S[], Exclude<T, S>[]];
+declare function partition<T>(arr: T[], resolver: (arg: T) => boolean): [T[], T[]]
+export default partition;


### PR DESCRIPTION
fixes: https://github.com/angus-c/just/issues/584

\- using a utility from `type-fest` to check if the types are what is desired/expected

**Before:**
<img width="584" alt="Screenshot 2024-09-03 at 20 07 48" src="https://github.com/user-attachments/assets/ab8dc576-64b7-4d21-b4a0-cca4dd4a9fdf">

**After**
<img width="584" alt="Screenshot 2024-09-03 at 20 00 35" src="https://github.com/user-attachments/assets/9a63c0ce-a8f8-4676-b9cf-2150a73c8905">
