### PR TITLE
Fix Github Action build errors, use `yarn exec` to run local version of `lerna`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,5 +23,5 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn && lerna bootstrap
+    - run: yarn && yarn exec lerna bootstrap
     - run: yarn test


### PR DESCRIPTION
I see that there are build errors with node v14 - v16, 

e.g. 
* https://github.com/angus-c/just/pull/585/checks
* https://github.com/angus-c/just/pull/578/checks
* https://github.com/angus-c/just/pull/571/checks

It appears that this may be due to the Github action using global install of `lerna` as opposed to the version in `node_modules`